### PR TITLE
Switched to using junit-dep

### DIFF
--- a/fluentlenium-core/pom.xml
+++ b/fluentlenium-core/pom.xml
@@ -52,8 +52,7 @@
         </dependency>
         <dependency>
             <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>provided</scope>
+            <artifactId>junit-dep</artifactId>
         </dependency>
 
         <dependency>

--- a/fluentlenium-festassert/pom.xml
+++ b/fluentlenium-festassert/pom.xml
@@ -60,7 +60,7 @@
         </dependency>
         <dependency>
             <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <artifactId>junit-dep</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/fluentlenium-testng/pom.xml
+++ b/fluentlenium-testng/pom.xml
@@ -66,8 +66,14 @@
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <version>${testng.version}</version>
+            <exclusions>
+                <exclusion>
+                    <!-- I kid you not, testng depends on junit 3 -->
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
-
     </dependencies>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
             </dependency>
             <dependency>
                 <groupId>junit</groupId>
-                <artifactId>junit</artifactId>
+                <artifactId>junit-dep</artifactId>
                 <version>4.8.2</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
Not sure if you're aware, but junit is evil, it bundles its dependent libraries, eg hamcrest, into its own jar.  This creates classloader hell if some other library depends on a different version of hamcrest.

junit-dep on the other hand doesn't bundle its dependencies, but rather has a proper pom.xml file to declare its dependencies so they are brought in transitively.

I saw that you had junit-dep marked as provided scope.  Maybe this was to work around the issue, because in maven 3 it stops it from being transitively brought into projects?  Using junit-dep I think is a better solution to the problem.
