### PR TITLE
Incorrect areEnabled error messages and test method names

### DIFF
--- a/fluentlenium-core/src/main/java/org/fluentlenium/core/wait/FluentWaitMatcher.java
+++ b/fluentlenium-core/src/main/java/org/fluentlenium/core/wait/FluentWaitMatcher.java
@@ -257,13 +257,13 @@ public class FluentWaitMatcher {
         return FluentThread.get();
     }
 
-     /**
+    /**
      * Check that the elements are all enabled
      *
      * @return
      */
     public Fluent areEnabled() {
-        Predicate isVisible = new com.google.common.base.Predicate<WebDriver>() {
+        Predicate isEnabled = new com.google.common.base.Predicate<WebDriver>() {
             public boolean apply(@Nullable WebDriver webDriver) {
                 if (filters.size() > 0) {
                     FluentList<FluentWebElement> fluentWebElements = search.find(selector, (Filter[]) filters.toArray(new Filter[filters.size()]));
@@ -289,7 +289,7 @@ public class FluentWaitMatcher {
                 return false;
             }
         };
-        until(wait, isVisible, filters, isDisplayedMessage(selector));
+        until(wait, isEnabled, filters, isEnabledMessage(selector));
         return FluentThread.get();
     }
 

--- a/fluentlenium-core/src/main/java/org/fluentlenium/core/wait/WaitMessage.java
+++ b/fluentlenium-core/src/main/java/org/fluentlenium/core/wait/WaitMessage.java
@@ -27,6 +27,7 @@ public class WaitMessage {
     private static final String IS_NOT_GREATHER_THAN_OR_EQUAL_TO = " is not greather than or equal to ";
     private static final String IS_NOT_LOADED = " is not loaded";
     private static final String IS_NOT_DISPLAY = " is not displayed";
+    private static final String IS_NOT_ENABLED = " is not enabled";
 
     static final String hasSizeMessage(String selector, int size) {
         return SELECTOR + selector + HAS_NOT_THE_SIZE + size + POINT;
@@ -50,6 +51,10 @@ public class WaitMessage {
 
     static final String isDisplayedMessage(String selector) {
         return SELECTOR + selector + IS_NOT_DISPLAY;
+    }
+
+	static final String isEnabledMessage(String selector) {
+        return SELECTOR + selector + IS_NOT_ENABLED;
     }
 
     static final String hasTextMessage(String selector, String value) {

--- a/fluentlenium-core/src/test/java/org/fluentlenium/integration/FluentLeniumWaitTest.java
+++ b/fluentlenium-core/src/test/java/org/fluentlenium/integration/FluentLeniumWaitTest.java
@@ -117,12 +117,12 @@ public class FluentLeniumWaitTest extends LocalFluentCase {
 
 
     @Test
-    public void when_a_element_is_not_present_then_isNotEnabled_return_true() {
+    public void when_a_element_is_not_present_then_isNotPresent_return_true() {
         await().atMost(1, NANOSECONDS).until(".small").withText().contains("notPresent").isNotPresent();
     }
 
     @Test(expected = TimeoutException.class)
-    public void when_a_element_is_present_then_isNotEnabled_throw_an_exception() {
+    public void when_a_element_is_present_then_isNotPresent_throw_an_exception() {
         await().atMost(1, NANOSECONDS).until(".small").withText().contains("Small 1").isNotPresent();
     }
 
@@ -239,13 +239,13 @@ public class FluentLeniumWaitTest extends LocalFluentCase {
     }
 
     @Test
-    public void when_element_is_present_then_areEnabled_return_true() {
+    public void when_element_is_enabled_then_areEnabled_return_true() {
         goTo(JAVASCRIPT_URL);
         await().atMost(1, NANOSECONDS).until("#default").areEnabled();
     }
 
     @Test(expected = TimeoutException.class)
-    public void when_element_is_not_displayed_then_areEnabled_throws_exception() {
+    public void when_element_is_not_enabled_then_areEnabled_throws_exception() {
         goTo(JAVASCRIPT_URL);
         await().atMost(1, NANOSECONDS).until("#disabled").areEnabled();
     }


### PR DESCRIPTION
FluentWaitMatcher.areEnabled() returns an incorrect error message and some FluentWaitMatcher test method names do not match the tested behavior.
