### PR TITLE
FluentLenium doesnt work with FF19 at least on Ubuntu

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
             <dependency>
                 <groupId>org.seleniumhq.selenium</groupId>
                 <artifactId>selenium-java</artifactId>
-                <version>2.29.0</version>
+                <version>2.30.0</version>
             </dependency>
             <dependency>
                 <groupId>junit</groupId>


### PR DESCRIPTION
It's fixed as usual by updating Selenium-java to the last version.
