### PR TITLE
move quit check to FluentAdapter

### DIFF
--- a/fluentlenium-core/src/main/java/org/fluentlenium/adapter/FluentTest.java
+++ b/fluentlenium-core/src/main/java/org/fluentlenium/adapter/FluentTest.java
@@ -60,9 +60,7 @@ public abstract class FluentTest extends FluentAdapter {
         @Override
         public void finished(FrameworkMethod method) {
             super.finished(method);
-            if (getDriver() != null) {
-                quit();
-            }
+            quit();
         }
 
         @Override

--- a/fluentlenium-core/src/main/java/org/fluentlenium/core/FluentAdapter.java
+++ b/fluentlenium-core/src/main/java/org/fluentlenium/core/FluentAdapter.java
@@ -155,7 +155,9 @@ public class FluentAdapter extends Fluent {
     }
 
     public void quit() {
-        getDriver().quit();
+        if (getDriver() != null) {
+            getDriver().quit();
+        }
     }
 
 }

--- a/fluentlenium-testng/src/main/java/org/fluentlenium/adapter/FluentTestNg.java
+++ b/fluentlenium-testng/src/main/java/org/fluentlenium/adapter/FluentTestNg.java
@@ -35,9 +35,7 @@ public abstract class FluentTestNg extends FluentAdapter {
 
     @AfterClass
     public void afterClass() {
-        if (getDriver() != null) {
-            getDriver().quit();
-        }
+        quit();
     }
 
 }


### PR DESCRIPTION
finished method on FluentTest is checking if driver is not null but it should be done in FluentAdapter
