### PR TITLE
Make the current url relative to the base url if provided

### DIFF
--- a/fluentlenium-core/src/main/java/org/fluentlenium/core/Fluent.java
+++ b/fluentlenium-core/src/main/java/org/fluentlenium/core/Fluent.java
@@ -174,12 +174,18 @@ public abstract class Fluent implements SearchActions {
     }
 
     /**
-     * Return the url of the page
+     * Return the url of the page. If a base url is provided, the current url will be relative to that base url.
      *
      * @return
      */
     public String url() {
-        return driver.getCurrentUrl();
+        String currentUrl = driver.getCurrentUrl();
+
+        if (currentUrl != null && baseUrl != null && currentUrl.startsWith(baseUrl)) {
+            currentUrl = currentUrl.substring(baseUrl.length());
+        }
+
+        return currentUrl;
     }
 
     /**


### PR DESCRIPTION
This makes testing more intuitive:

```
browser.withDefaultUrl("http://github.com")
browser.goTo("/")
browser.url must equalTo("/")
```

Without this fix the last check fails, because the returned url is http://github.com/
