### PR TITLE
Alias for the fill method so it doesn't clash with the Scala keyword

### DIFF
--- a/fluentlenium-core/src/main/java/org/fluentlenium/core/action/FillConstructor.java
+++ b/fluentlenium-core/src/main/java/org/fluentlenium/core/action/FillConstructor.java
@@ -47,4 +47,9 @@ public class FillConstructor extends org.fluentlenium.core.Fluent {
         }
         return this;
     }
+
+    public FillConstructor withValues(String... values) {
+        // with is a reserved word in Scala...
+        return with(values);
+    }
 }


### PR DESCRIPTION
In Scala with is a reserved word, forcing you to write ugly code like:

```
fill("#myForm").`with`("foo", "bar")
```

A simply alias (for instance withValues) will fix this.