### PR TITLE
Add test and doc for FindBy annotation in page

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -402,6 +402,29 @@ public class LoginPage extends FluentPage {
    }
 }
 ```
+
+If the naming conventions of your HTML ids and names don't match with the naming conventions of your Java fields,
+or if you want to select an element with something other than the id or name, you can annotate the field with the
+Selenium `@FindBy` (or `@FindBys`) annotation. The following example shows how to find the create button if its CSS class is
+`create-button`.
+
+```java
+public class LoginPage extends FluentPage {
+   @FindBy(css = "button.create-button")
+   FluentWebElement createButton;
+   public String getUrl() {
+       return "myCustomUrl";
+   }
+   public void isAt() {
+       assertThat(title()).isEqualTo("MyTitle");
+   }
+   public void fillAndSubmitForm(String... paramsOrdered) {
+       fill("input").with(paramsOrdered);
+       createButton.click();
+   }
+}
+```
+
 If you need to wait for an element to be present, especially when waiting for an ajax call to complete, you can use the @AjaxElement annotation on the fields :
 
 ```java

--- a/fluentlenium-core/src/test/html/index.html
+++ b/fluentlenium-core/src/test/html/index.html
@@ -30,6 +30,7 @@
 <input id="name" value="John" type="text"/>
 <input id="firstname" value="Doe" type="text"/>
 <a href="page2.html" id="linkToPage2">Next Page</a>
+<a href="page2.html" class="go-next">FindBy test</a>
 <span class="child">Paul</span>
 
 <span class="parent">

--- a/fluentlenium-core/src/test/java/org/fluentlenium/integration/PageTest.java
+++ b/fluentlenium-core/src/test/java/org/fluentlenium/integration/PageTest.java
@@ -20,6 +20,7 @@ import org.fluentlenium.core.domain.FluentWebElement;
 import org.fluentlenium.integration.localtest.LocalFluentCase;
 import org.junit.ComparisonFailure;
 import org.junit.Test;
+import org.openqa.selenium.support.FindBy;
 
 import static org.fest.assertions.Assertions.assertThat;
 
@@ -51,7 +52,7 @@ public class PageTest extends LocalFluentCase {
     @Test
     public void checkFollowLink() {
         page.go();
-        page.goToNexPage();
+        page.goToNextPage();
         page2.isAt();
     }
 
@@ -59,14 +60,24 @@ public class PageTest extends LocalFluentCase {
     public void checkFollowLinkWithBddStyle() {
         goTo(page);
         assertAt(page);
-        page.goToNexPage();
+        page.goToNextPage();
         assertAt(page2);
+    }
+
+    @Test
+    public void checkFollowLinkFoundWithFindBy() {
+        page.go();
+        page.goToNextPageWithFindByClassLink();
+        page2.isAt();
     }
 }
 
 class PageAccueil extends FluentPage {
 
     FluentWebElement linkToPage2;
+
+    @FindBy(css = "a.go-next")
+    FluentWebElement linkToPage2FoundWithFindBy;
 
     @Override
     public String getUrl() {
@@ -78,8 +89,12 @@ class PageAccueil extends FluentPage {
         assertThat($("title").first().getText()).contains("Selenium");
     }
 
-    public void goToNexPage() {
+    public void goToNextPage() {
         linkToPage2.click();
+    }
+
+    public void goToNextPageWithFindByClassLink() {
+        linkToPage2FoundWithFindBy.click();
     }
 }
 

--- a/fluentlenium-cucumber/src/test/java/org/fluentlenium/cucumber/step/SimpleFeatureMultiStep2.java
+++ b/fluentlenium-cucumber/src/test/java/org/fluentlenium/cucumber/step/SimpleFeatureMultiStep2.java
@@ -39,7 +39,7 @@ public class SimpleFeatureMultiStep2 extends FluentCucumberTest {
         this.initFluent();
         this.initTest();
 
-        click("a");
+        click("a#linkToPage2");
     }
 
     @Then(value = "feature multi2 I am on the second page")

--- a/fluentlenium-cucumber/src/test/java/org/fluentlenium/cucumber/step/SimpleFeatureStep.java
+++ b/fluentlenium-cucumber/src/test/java/org/fluentlenium/cucumber/step/SimpleFeatureStep.java
@@ -52,7 +52,7 @@ public class SimpleFeatureStep extends FluentCucumberTest {
         this.initFluent();
         this.initTest();
 
-        click("a");
+        click("a#linkToPage2");
     }
 
     @Then(value = "feature I am on the second page")

--- a/fluentlenium-cucumber/src/test/java/org/fluentlenium/cucumber/step/SimpleScenarioMultiStep2.java
+++ b/fluentlenium-cucumber/src/test/java/org/fluentlenium/cucumber/step/SimpleScenarioMultiStep2.java
@@ -42,7 +42,7 @@ public class SimpleScenarioMultiStep2 extends FluentCucumberTest {
         this.initFluent();
         this.initTest();
 
-		click("a");
+		click("a#linkToPage2");
     }
 
     @Then(value = "scenario multi2 I am on the second page")

--- a/fluentlenium-cucumber/src/test/java/org/fluentlenium/cucumber/step/SimpleScenarioStep.java
+++ b/fluentlenium-cucumber/src/test/java/org/fluentlenium/cucumber/step/SimpleScenarioStep.java
@@ -50,7 +50,7 @@ public class SimpleScenarioStep extends FluentCucumberTest {
 		this.initFluent();
 		this.initTest();
 
-        click("a");
+        click("a#linkToPage2");
     }
 
     @Then(value = "scenario I am on the second page")

--- a/fluentlenium-cucumber/src/test/resources/html/index.html
+++ b/fluentlenium-cucumber/src/test/resources/html/index.html
@@ -30,6 +30,7 @@
 <input id="name" value="John" type="text"/>
 <input id="firstname" value="Doe" type="text"/>
 <a href="page2.html" id="linkToPage2">Next Page</a>
+<a href="page2.html" class="go-next">FindBy test</a>
 <span class="child">Paul</span>
 
 <span class="parent">

--- a/fluentlenium-festassert/src/test/html/index.html
+++ b/fluentlenium-festassert/src/test/html/index.html
@@ -30,6 +30,7 @@
 <input id="name" value="John" type="text"/>
 <input id="firstname" value="Doe" type="text"/>
 <a href="page2.html" id="linkToPage2">Next Page</a>
+<a href="page2.html" class="go-next">FindBy test</a>
 <span class="child">Paul</span>
 
 <span class="parent">

--- a/fluentlenium-testng/src/test/html/index.html
+++ b/fluentlenium-testng/src/test/html/index.html
@@ -30,6 +30,7 @@
 <input id="name" value="John" type="text"/>
 <input id="firstname" value="Doe" type="text"/>
 <a href="page2.html" id="linkToPage2">Next Page</a>
+<a href="page2.html" class="go-next">FindBy test</a>
 <span class="child">Paul</span>
 
 <span class="parent">

--- a/fluentlenium-testng/src/test/java/org/fluentlenium/integration/PageTest.java
+++ b/fluentlenium-testng/src/test/java/org/fluentlenium/integration/PageTest.java
@@ -19,6 +19,7 @@ import org.fluentlenium.core.annotation.Page;
 import org.fluentlenium.core.domain.FluentWebElement;
 import org.fluentlenium.integration.localtest.LocalFluentCase;
 import org.junit.ComparisonFailure;
+import org.openqa.selenium.support.FindBy;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -54,21 +55,31 @@ public class PageTest extends LocalFluentCase {
 
     @Test
     public void checkFollowLink() {
-        page.goToNexPage();
+        page.goToNextPage();
         page2.isAt();
     }
 
     @Test
     public void checkFollowLinkWithBddStyle() {
         assertAt(page);
-        page.goToNexPage();
+        page.goToNextPage();
         assertAt(page2);
+    }
+
+    @Test
+    public void checkFollowLinkFoundWithFindBy() {
+        page.go();
+        page.goToNextPageWithFindByClassLink();
+        page2.isAt();
     }
 }
 
 class PageAccueil extends FluentPage {
 
     FluentWebElement linkToPage2;
+
+    @FindBy(css = "a.go-next")
+    FluentWebElement linkToPage2FoundWithFindBy;
 
     @Override
     public String getUrl() {
@@ -80,8 +91,12 @@ class PageAccueil extends FluentPage {
         assertThat($("title").first().getText()).contains("Selenium");
     }
 
-    public void goToNexPage() {
+    public void goToNextPage() {
         linkToPage2.click();
+    }
+
+    public void goToNextPageWithFindByClassLink() {
+        linkToPage2FoundWithFindBy.click();
     }
 }
 

--- a/src/test/html/index.html
+++ b/src/test/html/index.html
@@ -30,6 +30,7 @@
 <input id="name" value="John" type="text"/>
 <input id="firstname" value="Doe" type="text"/>
 <a href="page2.html" id="linkToPage2">Next Page</a>
+<a href="page2.html" class="go-next">FindBy test</a>
 <span class="child">Paul</span>
 
 <span class="parent">


### PR DESCRIPTION
Could you please test this pull request before I send it to the upstream repo? The idea is to be able to use FluentWebElement in pages even if the name of the field (for example "createButton") doesn't match with the ID or name of the element (for example "create_button"). I realized that this is natively supported by Selenium, although not documented in FluentLenium, so I added a bit of documentation, and added a TestCase just to make sure this actually works.
