### PR TITLE
Select as a fluent element (request #75)

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -242,6 +242,8 @@ you can also use the filtering provided by FluentLenium `fill("input", with("typ
 `fill("input").with("myLogin","myPassword")` will fill the first element of the input selection with myLogin, the second with myPassword. 
 If there are more input elements found, the last value (myPassword) will be repeated for each subsequent element.
 
+If you're trying to fill a select element, you can use `fillSelect("daySelector").withValue("MONDAY")` to fill it with a value, `fillSelect("daySelector").withIndex(1)` to fill it with a value by its index or `fillSelect("daySelector").withText("Monday")` to fill it with a value by its text.
+
 Don't forget, only visible fields will be modified. It simulates a real person using a browser!
 
 ### Click

--- a/fluentlenium-core/src/main/java/org/fluentlenium/core/Fluent.java
+++ b/fluentlenium-core/src/main/java/org/fluentlenium/core/Fluent.java
@@ -16,6 +16,7 @@ package org.fluentlenium.core;
 
 import org.apache.commons.io.FileUtils;
 import org.fluentlenium.core.action.FillConstructor;
+import org.fluentlenium.core.action.FillSelectConstructor;
 import org.fluentlenium.core.action.FluentDefaultActions;
 import org.fluentlenium.core.annotation.AjaxElement;
 import org.fluentlenium.core.annotation.Page;
@@ -235,6 +236,7 @@ public abstract class Fluent implements SearchActions {
             throw new RuntimeException(e);
         }
     }
+
     /**
      * Get the base URL to use when visiting relative URLs, if one is configured
      *
@@ -417,6 +419,16 @@ public abstract class Fluent implements SearchActions {
      */
     public FillConstructor fill(FluentDefaultActions list, Filter... filters) {
         return new FillConstructor(list, getDriver(), filters);
+    }
+
+    /**
+     * Construct a FillSelectConstructor in order to allow easy fill
+     * Be careful - only the visible elements are filled
+     *
+     * @param cssSelector
+     */
+    public FillSelectConstructor fillSelect(String cssSelector, Filter... filters) {
+        return new FillSelectConstructor(cssSelector, getDriver(), filters);
     }
 
     /**

--- a/fluentlenium-core/src/main/java/org/fluentlenium/core/action/FillSelectConstructor.java
+++ b/fluentlenium-core/src/main/java/org/fluentlenium/core/action/FillSelectConstructor.java
@@ -1,0 +1,67 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package org.fluentlenium.core.action;
+
+import org.fluentlenium.core.filter.Filter;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.Select;
+
+public class FillSelectConstructor extends org.fluentlenium.core.Fluent {
+    private String cssSelector;
+    private Filter[] filters;
+
+    public FillSelectConstructor(String cssSelector, WebDriver webDriver, Filter... filters) {
+        super(webDriver);
+        this.cssSelector = cssSelector;
+        this.filters = filters;
+    }
+
+    /**
+     * Select all options that have a value matching the argument for the Select element.
+     *
+     * @param value
+     */
+    public FillSelectConstructor withValue(String value) {
+        WebElement selectElement = findFirst(cssSelector, filters).getElement();
+        Select select = new Select(selectElement);
+        select.selectByValue(value);
+        return this;
+    }
+
+    /**
+     * Select the option by its index for the Select element.
+     *
+     * @param index
+     */
+    public FillSelectConstructor withIndex(int index) {
+        WebElement selectElement = findFirst(cssSelector, filters).getElement();
+        Select select = new Select(selectElement);
+        select.selectByIndex(index);
+        return this;
+    }
+
+    /**
+     * Select all options that display text matching the argument for the Select element.
+     *
+     * @param text
+     */
+    public FillSelectConstructor withText(String text) {
+        WebElement selectElement = findFirst(cssSelector, filters).getElement();
+        Select select = new Select(selectElement);
+        select.selectByVisibleText(text);
+        return this;
+    }
+}

--- a/fluentlenium-core/src/test/html/index.html
+++ b/fluentlenium-core/src/test/html/index.html
@@ -42,5 +42,10 @@
 
 <span generated="true">Test custom attribute
 </span>
+<select id="select">
+    <option value="value-1">value 1</option>
+    <option value="value-2">value 2</option>
+    <option value="value-3">value 3</option>
+</select>
 </body>
 </html>

--- a/fluentlenium-core/src/test/java/org/fluentlenium/integration/ActionOnSelectorWithBddTest.java
+++ b/fluentlenium-core/src/test/java/org/fluentlenium/integration/ActionOnSelectorWithBddTest.java
@@ -16,6 +16,7 @@ package org.fluentlenium.integration;
 
 import org.fluentlenium.integration.localtest.LocalFluentCase;
 import org.junit.Test;
+import org.openqa.selenium.support.ui.Select;
 
 import static org.fest.assertions.Assertions.assertThat;
 
@@ -26,6 +27,18 @@ public class ActionOnSelectorWithBddTest extends LocalFluentCase {
         assertThat(findFirst("#name").getValue()).contains("John");
         fill(findFirst("#name")).with("zzz");
         assertThat(findFirst("#name").getValue()).isEqualTo("zzz");
+    }
+
+    @Test
+    public void checkFillSelectAction() {
+        goTo(DEFAULT_URL);
+        Select select = new Select(findFirst("#select").getElement());
+        fillSelect("#select").withValue("value-1"); // by value
+        assertThat(select.getFirstSelectedOption().getText()).isEqualTo("value 1");
+        fillSelect("#select").withIndex(1); // by index
+        assertThat(select.getFirstSelectedOption().getText()).isEqualTo("value 2");
+        fillSelect("#select").withText("value 3"); // by text
+        assertThat(select.getFirstSelectedOption().getText()).isEqualTo("value 3");
     }
 
     @Test

--- a/fluentlenium-cucumber/src/test/resources/html/index.html
+++ b/fluentlenium-cucumber/src/test/resources/html/index.html
@@ -42,5 +42,10 @@
 
 <span generated="true">Test custom attribute
 </span>
+<select id="select">
+    <option value="value-1">value 1</option>
+    <option value="value-2">value 2</option>
+    <option value="value-3">value 3</option>
+</select>
 </body>
 </html>

--- a/fluentlenium-festassert/src/test/html/index.html
+++ b/fluentlenium-festassert/src/test/html/index.html
@@ -38,8 +38,14 @@
 <input id="selected" type="checkbox" value="John" checked/>
 <input id="disabled" type="checkbox" value="John" disabled="disabled"/>
 <input id="non_display" type="checkbox" value="John" style="display:none;"/>
+<button class="class1 class2 class3">Multiple css class</button>
 
 <span generated="true">Test custom attribute
 </span>
+<select id="select">
+    <option value="value-1">value 1</option>
+    <option value="value-2">value 2</option>
+    <option value="value-3">value 3</option>
+</select>
 </body>
 </html>

--- a/fluentlenium-testng/src/test/html/index.html
+++ b/fluentlenium-testng/src/test/html/index.html
@@ -38,8 +38,14 @@
 <input id="selected" type="checkbox" value="John" checked/>
 <input id="disabled" type="checkbox" value="John" disabled="disabled"/>
 <input id="non_display" type="checkbox" value="John" style="display:none;"/>
+<button class="class1 class2 class3">Multiple css class</button>
 
 <span generated="true">Test custom attribute
 </span>
+<select id="select">
+    <option value="value-1">value 1</option>
+    <option value="value-2">value 2</option>
+    <option value="value-3">value 3</option>
+</select>
 </body>
 </html>

--- a/src/test/html/index.html
+++ b/src/test/html/index.html
@@ -42,5 +42,10 @@
 
 <span generated="true">Test custom attribute
 </span>
+<select id="select">
+    <option value="value-1">value 1</option>
+    <option value="value-2">value 2</option>
+    <option value="value-3">value 3</option>
+</select>
 </body>
 </html>


### PR DESCRIPTION
Allows to build a `fillSelect(cssSelector)` and to set value by value or index or text as proposed in request #75.

I implemented it with a new class `FillSelectConstructor`. I don't know if it's the best way, if you have another idea, let me know. Added test cases and docs too.
