### PR TITLE
Added method FluentWaitMatcher.areNotDisplayed()

### DIFF
--- a/fluentlenium-core/src/main/java/org/fluentlenium/core/wait/FluentWaitMatcher.java
+++ b/fluentlenium-core/src/main/java/org/fluentlenium/core/wait/FluentWaitMatcher.java
@@ -271,6 +271,27 @@ public class FluentWaitMatcher {
     }
 
     /**
+     * Check that the elements are all not displayed
+     *
+     * @return
+     */
+    public Fluent areNotDisplayed() {
+        Predicate isNotVisible = new com.google.common.base.Predicate<WebDriver>() {
+            public boolean apply(WebDriver webDriver) {
+                FluentList<FluentWebElement> fluentWebElements = search.find(selector, (Filter[]) filters.toArray(new Filter[filters.size()]));
+                for (FluentWebElement fluentWebElement : fluentWebElements) {
+                    if (fluentWebElement.isDisplayed()) {
+                        return false;
+                    }
+                }
+                return true;
+            }
+        };
+        until(wait, isNotVisible, filters, isDisplayedMessage(selector));
+        return FluentThread.get();
+    }
+
+    /**
      * Check that the elements are all enabled
      *
      * @return

--- a/fluentlenium-core/src/test/java/org/fluentlenium/integration/FluentLeniumWaitTest.java
+++ b/fluentlenium-core/src/test/java/org/fluentlenium/integration/FluentLeniumWaitTest.java
@@ -260,6 +260,24 @@ public class FluentLeniumWaitTest extends LocalFluentCase {
     }
 
     @Test
+    public void when_element_is_not_present_then_areNotDisplayed_return_true() {
+        goTo(JAVASCRIPT_URL);
+        await().atMost(1, NANOSECONDS).until("#nonexistent").areNotDisplayed();
+    }
+
+    @Test
+    public void when_element_is_not_displayed_then_areNotDisplayed_return_true() {
+        goTo(JAVASCRIPT_URL);
+        await().atMost(1, NANOSECONDS).until("#unvisible").areNotDisplayed();
+    }
+
+    @Test(expected = TimeoutException.class)
+    public void when_element_is_displayed_then_areNotDisplayed_throws_exception() {
+        goTo(JAVASCRIPT_URL);
+        await().atMost(1, NANOSECONDS).until("#default").areNotDisplayed();
+    }
+
+    @Test
     public void when_element_is_enabled_then_areEnabled_return_true() {
         goTo(JAVASCRIPT_URL);
         await().atMost(1, NANOSECONDS).until("#default").areEnabled();


### PR DESCRIPTION
The `FluentWaitMatcher.areNotDisplayed()` method is simply the opposite sister of `FluentWaitMatcher.areDisplayed()`.
