### PR TITLE
Avoiding StackOverflowError when cyclic dependency between pages

### DIFF
--- a/fluentlenium-core/src/main/java/org/fluentlenium/core/FluentAdapter.java
+++ b/fluentlenium-core/src/main/java/org/fluentlenium/core/FluentAdapter.java
@@ -25,13 +25,19 @@ import org.openqa.selenium.support.pagefactory.ElementLocator;
 import org.openqa.selenium.support.pagefactory.ElementLocatorFactory;
 import org.openqa.selenium.support.pagefactory.internal.LocatingElementHandler;
 
-import java.lang.reflect.*;
-import java.util.HashMap;
-import java.util.Map;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.Proxy;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 public class FluentAdapter extends Fluent {
 
-    private final Map<Class, FluentPage> pageInstances = new HashMap<Class, FluentPage>();
+    private final ConcurrentMap<Class, FluentPage> pageInstances = new ConcurrentHashMap<Class, FluentPage>();
 
     public FluentAdapter(WebDriver webDriver) {
         super(webDriver);
@@ -52,7 +58,7 @@ public class FluentAdapter extends Fluent {
         }
     }
 
-    protected void cleanUpTest() {
+    protected void cleanUp() {
         pageInstances.clear();
     }
 
@@ -72,7 +78,7 @@ public class FluentAdapter extends Fluent {
                     } else {
                         FluentPage page = initClass(clsPage);
                         field.set(container, page);
-                        pageInstances.put(clsPage, page);
+                        pageInstances.putIfAbsent(clsPage, page);
                         injectPageIntoContainer(page);
                     }
                 }

--- a/fluentlenium-core/src/main/java/org/fluentlenium/core/FluentAdapter.java
+++ b/fluentlenium-core/src/main/java/org/fluentlenium/core/FluentAdapter.java
@@ -100,7 +100,6 @@ public class FluentAdapter extends Fluent {
 
             //init fields with default proxies
             initFluentWebElements(page);
-
             return page;
         } catch (ClassNotFoundException e) {
             throw new ConstructionException("Class " + cls.getName() + "not found", e);

--- a/fluentlenium-core/src/main/java/org/fluentlenium/core/FluentAdapter.java
+++ b/fluentlenium-core/src/main/java/org/fluentlenium/core/FluentAdapter.java
@@ -26,8 +26,12 @@ import org.openqa.selenium.support.pagefactory.ElementLocatorFactory;
 import org.openqa.selenium.support.pagefactory.internal.LocatingElementHandler;
 
 import java.lang.reflect.*;
+import java.util.HashMap;
+import java.util.Map;
 
 public class FluentAdapter extends Fluent {
+
+    private final Map<Class, FluentPage> pageInstances = new HashMap<Class, FluentPage>();
 
     public FluentAdapter(WebDriver webDriver) {
         super(webDriver);
@@ -58,9 +62,15 @@ public class FluentAdapter extends Fluent {
                     field.setAccessible(true);
                     Class clsField = field.getType();
                     Class clsPage = Class.forName(clsField.getName());
-                    FluentPage page = initClass(clsPage);
-                    field.set(container, page);
-                    injectPageIntoContainer(page);
+                    Fluent existingPage = pageInstances.get(clsPage);
+                    if (existingPage != null) {
+                        field.set(container, existingPage);
+                    } else {
+                        FluentPage page = initClass(clsPage);
+                        field.set(container, page);
+                        pageInstances.put(clsPage, page);
+                        injectPageIntoContainer(page);
+                    }
                 }
             }
         }

--- a/fluentlenium-core/src/main/java/org/fluentlenium/core/FluentAdapter.java
+++ b/fluentlenium-core/src/main/java/org/fluentlenium/core/FluentAdapter.java
@@ -52,6 +52,10 @@ public class FluentAdapter extends Fluent {
         }
     }
 
+    protected void cleanUpTest() {
+        pageInstances.clear();
+    }
+
     private void injectPageIntoContainer(Fluent container)
             throws ClassNotFoundException, IllegalAccessException {
         for (Class cls = container.getClass();

--- a/fluentlenium-testng/src/main/java/org/fluentlenium/adapter/FluentTestNg.java
+++ b/fluentlenium-testng/src/main/java/org/fluentlenium/adapter/FluentTestNg.java
@@ -66,7 +66,7 @@ public abstract class FluentTestNg extends FluentAdapter {
 
     @AfterMethod
     public void afterMethod() {
-        cleanUpTest();
+        cleanUp();
         if (SharedDriverHelper.isSharedDriverPerMethod(this.getClass())|| SharedDriverHelper.isDefaultSharedDriver(this.getClass())) {
             quit();
         } else if (SharedDriverHelper.isDeleteCookies(this.getClass())) {

--- a/fluentlenium-testng/src/main/java/org/fluentlenium/adapter/FluentTestNg.java
+++ b/fluentlenium-testng/src/main/java/org/fluentlenium/adapter/FluentTestNg.java
@@ -66,7 +66,7 @@ public abstract class FluentTestNg extends FluentAdapter {
 
     @AfterMethod
     public void afterMethod() {
-        //)
+        cleanUpTest();
         if (SharedDriverHelper.isSharedDriverPerMethod(this.getClass())|| SharedDriverHelper.isDefaultSharedDriver(this.getClass())) {
             quit();
         } else if (SharedDriverHelper.isDeleteCookies(this.getClass())) {

--- a/fluentlenium-testng/src/test/java/org/fluentlenium/integration/CyclicDependencyTest.java
+++ b/fluentlenium-testng/src/test/java/org/fluentlenium/integration/CyclicDependencyTest.java
@@ -1,0 +1,101 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package org.fluentlenium.integration;
+
+import org.fluentlenium.core.FluentPage;
+import org.fluentlenium.core.annotation.Page;
+import org.fluentlenium.integration.localtest.LocalFluentCase;
+import org.testng.annotations.Test;
+
+/**
+ * @author Tomasz Nurkiewicz
+ * @since 7/28/13, 11:05 AM
+ */
+public class CyclicDependencyTest extends LocalFluentCase {
+
+    @Page
+    private MainPage mainPage;
+
+    @Test
+    public void simpleCyclicDependency() {
+        mainPage.
+                openDialog().
+                showPanel().
+                hide().
+                close().
+                done();
+    }
+
+    @Test
+    public void cyclicDependencyWithMultipleSteps() {
+        mainPage.
+                openDialog().
+                showPanel().
+                closeAll().
+                openDialog();
+    }
+
+}
+
+class MainPage extends FluentPage {
+
+    @Page
+    private Dialog dialog;
+
+    public Dialog openDialog() {
+        return dialog;
+    }
+
+    public MainPage done() {
+        return this;
+    }
+
+}
+
+class Dialog extends FluentPage {
+
+    @Page
+    private Panel panel;
+
+    @Page
+    private MainPage mainPage;
+
+    public Panel showPanel() {
+        return panel;
+    }
+
+    public MainPage close() {
+        return mainPage;
+    }
+
+}
+
+class Panel extends FluentPage {
+
+    @Page
+    private Dialog dialog;
+
+    @Page
+    private MainPage mainPage;
+
+    public Dialog hide() {
+        return dialog;
+    }
+
+    public MainPage closeAll() {
+        return mainPage;
+    }
+
+}


### PR DESCRIPTION
Cyclic dependencies aren't generally a good idea but sometimes useful, e.g.:

```java
class MainPage extends FluentPage {

	@Page private Dialog dialog;

	public Dialog openDialog() { return dialog; }

	public MainPage done() { return this; }

}

class Dialog extends FluentPage {

	@Page private Panel panel;

	@Page private MainPage mainPage;

	public Panel showPanel() { return panel; }

	public MainPage close() { return mainPage; }

}

class Panel extends FluentPage {

	@Page private Dialog dialog;

	public Dialog hide() { return dialog; }

}
```

This allows me to write readable and fluent flows:

```java
mainPage.
		openDialog().
		showPanel().
		hide().
		close().
		done();
```

Unfortunately FluentLenium enters infinite recursive loop while traversing this cycle resulting in `StackOverflowError`:

	at org.fluentlenium.core.FluentAdapter.injectPageIntoContainer(FluentAdapter.java:66)
	at org.fluentlenium.core.FluentAdapter.injectPageIntoContainer(FluentAdapter.java:66)

This pull request attempts to fix the problem by caching already created and instrumented pages. Also some dead code was removed.