### PR TITLE
Throw exception if click("#selector") is done on wrong selector.

### DIFF
--- a/fluentlenium-core/src/main/java/org/fluentlenium/core/domain/FluentList.java
+++ b/fluentlenium-core/src/main/java/org/fluentlenium/core/domain/FluentList.java
@@ -53,6 +53,10 @@ public class  FluentList<E extends FluentWebElement> extends ArrayList<E> implem
      * Only the visible elements are filled
      */
     public FluentList click() {
+        if (this.size() == 0) {
+            throw new NoSuchElementException("No Element found");
+        }
+        
         for (E fluentWebElement : this) {
             if (fluentWebElement.isEnabled()) {
                 fluentWebElement.click();

--- a/fluentlenium-core/src/test/java/org/fluentlenium/integration/ActionOnSelectorTest.java
+++ b/fluentlenium-core/src/test/java/org/fluentlenium/integration/ActionOnSelectorTest.java
@@ -16,8 +16,8 @@ package org.fluentlenium.integration;
 
 import org.fluentlenium.integration.localtest.LocalFluentCase;
 import org.junit.Test;
-
 import static org.fest.assertions.Assertions.assertThat;
+import org.openqa.selenium.NoSuchElementException;
 
 public class ActionOnSelectorTest extends LocalFluentCase {
 
@@ -46,6 +46,18 @@ public class ActionOnSelectorTest extends LocalFluentCase {
         assertThat(title()).isEqualTo("Page 2");
     }
 
+    @Test
+    public void checkClickActionWrongSelector() {
+        goTo(DEFAULT_URL);
+        assertThat(title()).contains("Selenium");
+        try {
+            click("#BLUB");
+            org.junit.Assert.fail("NoSuchElementException should have been thrown!");
+        } catch(NoSuchElementException nsee) {
+            assertThat(nsee.getMessage()).startsWith("No Element found");
+        }
+    }    
+    
       @Test
     public void checkDoubleClickAction() {
         goTo(DEFAULT_URL);


### PR DESCRIPTION
I started to try the example and used a wrong selector in the click-Method.

``` java
public class LoginPage extends FluentPage {
..
        click("#wrong-selector");
..
```

No button got clicked and it was difficult to find the reason.
If click is done on wrong selector nothing has been done. Now if you do
a click with wrong selector a NoSuchElementException is thrown.
