### PR TITLE
Switch from junit-dep to junit

### DIFF
--- a/fluentlenium-core/pom.xml
+++ b/fluentlenium-core/pom.xml
@@ -51,7 +51,7 @@
         </dependency>
         <dependency>
             <groupId>junit</groupId>
-            <artifactId>junit-dep</artifactId>
+            <artifactId>junit</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/fluentlenium-cucumber/pom.xml
+++ b/fluentlenium-cucumber/pom.xml
@@ -63,7 +63,7 @@
         </dependency>
         <dependency>
             <groupId>junit</groupId>
-            <artifactId>junit-dep</artifactId>
+            <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/fluentlenium-festassert/pom.xml
+++ b/fluentlenium-festassert/pom.xml
@@ -60,7 +60,7 @@
         </dependency>
         <dependency>
             <groupId>junit</groupId>
-            <artifactId>junit-dep</artifactId>
+            <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/fluentlenium-testng/pom.xml
+++ b/fluentlenium-testng/pom.xml
@@ -70,7 +70,7 @@
         </dependency>
         <dependency>
             <groupId>junit</groupId>
-            <artifactId>junit-dep</artifactId>
+            <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
       </dependency>
       <dependency>
         <groupId>junit</groupId>
-        <artifactId>junit-dep</artifactId>
+        <artifactId>junit</artifactId>
         <version>4.11</version>
       </dependency>
       <dependency>
@@ -98,6 +98,20 @@
   </dependencyManagement>
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.1</version>
+        <configuration>
+          <source>1.6</source>
+          <target>1.6</target>
+          <encoding>UTF-8</encoding>
+          <optimize>true</optimize>
+          <showDeprecation>true</showDeprecation>
+          <showWarnings>true</showWarnings>
+          <compilerArgument>-Xlint:all,-serial,-path,-rawtypes,-unchecked</compilerArgument>
+        </configuration>
+      </plugin>
       <plugin>
         <artifactId>maven-failsafe-plugin</artifactId>
         <version>2.6</version>


### PR DESCRIPTION
With the release of junit 4.11 the junit package now behaves correctly and does not bundle dependencies so junit-dep is no longer necessary.
