### PR TITLE
bump selenium version to 2.39

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
       <dependency>
         <groupId>org.seleniumhq.selenium</groupId>
         <artifactId>selenium-java</artifactId>
-        <version>2.35.0</version>
+        <version>2.39.0</version>
       </dependency>
       <dependency>
         <groupId>junit</groupId>


### PR DESCRIPTION
After a Firefox upgrade to version 26, FluentLenium would not work anymore (without manual changes) because of an outdated selenium dependency.
