### PR TITLE
Fix typo in sample HTML files.

### DIFF
--- a/fluentlenium-assertj/src/test/html/index.html
+++ b/fluentlenium-assertj/src/test/html/index.html
@@ -23,7 +23,7 @@
 
 <span id="oneline">A single line of text</span>
 
-<span id="pharnacy">Pharmacy</span>
+<span id="location">Pharmacy</span>
 <span class="small" id="id" name="name">Small 1</span>
 <span class="small" id="id2" name="name2">Small 2</span>
 <span class="small">Small 3</span>

--- a/fluentlenium-core/src/test/html/index.html
+++ b/fluentlenium-core/src/test/html/index.html
@@ -23,7 +23,7 @@
 
 <span id="oneline">A single line of text</span>
 
-<span id="pharnacy">Pharmacy</span>
+<span id="location">Pharmacy</span>
 <span class="small" id="id" name="name">Small 1</span>
 <span class="small" id="id2" name="name2">Small 2</span>
 <span class="small">Small 3</span>

--- a/fluentlenium-core/src/test/java/org/fluentlenium/integration/SelectorOnLabsTest.java
+++ b/fluentlenium-core/src/test/java/org/fluentlenium/integration/SelectorOnLabsTest.java
@@ -205,7 +205,7 @@ public class SelectorOnLabsTest extends SauceLabsFluentCase {
     @Test
     public void checkHtmlAction() {
         goTo(DEFAULT_URL);
-        assertThat($("#pharnacy").first().html().equals("Pharmacy"));
+        assertThat($("#location").first().html().equals("Pharmacy"));
     }
 
 }

--- a/fluentlenium-cucumber/src/test/resources/html/index.html
+++ b/fluentlenium-cucumber/src/test/resources/html/index.html
@@ -23,7 +23,7 @@
 
 <span id="oneline">A single line of text</span>
 
-<span id="pharnacy">Pharmacy</span>
+<span id="location">Pharmacy</span>
 <span class="small" id="id" name="name">Small 1</span>
 <span class="small" id="id2" name="name2">Small 2</span>
 <span class="small">Small 3</span>

--- a/fluentlenium-festassert/src/test/html/index.html
+++ b/fluentlenium-festassert/src/test/html/index.html
@@ -23,7 +23,7 @@
 
 <span id="oneline">A single line of text</span>
 
-<span id="pharnacy">Pharmacy</span>
+<span id="location">Pharmacy</span>
 <span class="small" id="id" name="name">Small 1</span>
 <span class="small" id="id2" name="name2">Small 2</span>
 <span class="small">Small 3</span>

--- a/fluentlenium-testng/src/test/html/index.html
+++ b/fluentlenium-testng/src/test/html/index.html
@@ -23,7 +23,7 @@
 
 <span id="oneline">A single line of text</span>
 
-<span id="pharnacy">Pharmacy</span>
+<span id="location">Pharmacy</span>
 <span class="small" id="id" name="name">Small 1</span>
 <span class="small" id="id2" name="name2">Small 2</span>
 <span class="small">Small 3</span>

--- a/src/test/html/index.html
+++ b/src/test/html/index.html
@@ -23,7 +23,7 @@
 
 <span id="oneline">A single line of text</span>
 
-<span id="pharnacy">Pharmacy</span>
+<span id="location">Pharmacy</span>
 <span class="small" id="id" name="name">Small 1</span>
 <span class="small" id="id2" name="name2">Small 2</span>
 <span class="small">Small 3</span>


### PR DESCRIPTION
- Use location instead of pharmacy to differentiate between ID and text.
