### PR TITLE
Add Field to Fluent Class

### DIFF
--- a/fluentlenium-core/src/main/java/org/fluentlenium/core/Fluent.java
+++ b/fluentlenium-core/src/main/java/org/fluentlenium/core/Fluent.java
@@ -50,7 +50,7 @@ public abstract class Fluent implements SearchActions {
     private WebDriver driver;
     private String baseUrl;
     private Search search;
-	private Object jsExecResult;
+    private Object jsExecResult;
 
     public Fluent(WebDriver driver) {
         this.driver = driver;
@@ -247,24 +247,24 @@ public abstract class Fluent implements SearchActions {
         return baseUrl;
     }
 
-	/**
-	 * Get the result of JS script execution that occurred in
-	 * {@link #executeScript(String)} method.
-	 *
-	 * @return the JS script execution result, or null in the following
-	 * cases:
-	 * <ul>
-	 *     <li>
-	 *         the {@link #executeScript(String)} wasn't called, otherwise if
-	 *     </li>
-	 *     <li>the result value is null, or</li>
-	 *     <li>there is no result to return.</li>
-	 * </ul>
-	 */
-	public Object getJsExecResult()
-	{
-		return jsExecResult;
-	}
+    /**
+     * Get the result of JS script execution that occurred in
+     * {@link #executeScript(String)} method.
+     *
+     * @return the JS script execution result, or null in the following
+     * cases:
+     * <ul>
+     *     <li>
+     *         the {@link #executeScript(String)} wasn't called, otherwise if
+     *     </li>
+     *     <li>the result value is null, or</li>
+     *     <li>there is no result to return.</li>
+     * </ul>
+     */
+    public Object getJsExecResult()
+    {
+        return jsExecResult;
+    }
 
     /**
      * wait for an asynchronous call

--- a/fluentlenium-core/src/main/java/org/fluentlenium/core/Fluent.java
+++ b/fluentlenium-core/src/main/java/org/fluentlenium/core/Fluent.java
@@ -50,6 +50,7 @@ public abstract class Fluent implements SearchActions {
     private WebDriver driver;
     private String baseUrl;
     private Search search;
+	private Object jsExecResult;
 
     public Fluent(WebDriver driver) {
         this.driver = driver;
@@ -246,6 +247,25 @@ public abstract class Fluent implements SearchActions {
         return baseUrl;
     }
 
+	/**
+	 * Get the result of JS script execution that occurred in
+	 * {@link #executeScript(String)} method.
+	 *
+	 * @return the JS script execution result, or null in the following
+	 * cases:
+	 * <ul>
+	 *     <li>
+	 *         the {@link #executeScript(String)} wasn't called, otherwise if
+	 *     </li>
+	 *     <li>the result value is null, or</li>
+	 *     <li>there is no result to return.</li>
+	 * </ul>
+	 */
+	public Object getJsExecResult()
+	{
+		return jsExecResult;
+	}
+
     /**
      * wait for an asynchronous call
      *
@@ -339,7 +359,7 @@ public abstract class Fluent implements SearchActions {
 
 
     public Fluent executeScript(String script) {
-        ((JavascriptExecutor) driver).executeScript(script);
+        jsExecResult = ((JavascriptExecutor) driver).executeScript(script);
         return this;
     }
 


### PR DESCRIPTION
The `org.fluentlenium.core.Fluent#executeScript` method doesn't return the script execution result and returns a reference to the same class instead. In many cases, the result of the script execution is needed when writing the test. Therefore adding a field that holds this result will make accessing it possible.