### PR TITLE
"find" method with only filters argument (#151)

### DIFF
--- a/fluentlenium-core/src/main/java/org/fluentlenium/core/Fluent.java
+++ b/fluentlenium-core/src/main/java/org/fluentlenium/core/Fluent.java
@@ -358,7 +358,19 @@ public abstract class Fluent implements SearchActions {
     public FluentList<FluentWebElement> $(String name, final Filter... filters) {
         return search.find(name, filters);
     }
-
+    
+    /**
+     * Central methods to find elements on the page with filters.
+     *
+     * @param filters
+     * @return
+     */
+    public FluentList<FluentWebElement> $(final Filter... filters) {
+        if (filters == null || filters.length == 0) {
+            throw new IllegalArgumentException("cssSelector or filter is required");
+        }
+        return $("*", filters);
+    }
 
     /**
      * Central methods a find element on the page, the number indicat the index of the desired element on the list. Can provide some filters. Able to use css1, css2, css3, see WebDriver  restrictions
@@ -371,6 +383,20 @@ public abstract class Fluent implements SearchActions {
         return search.find(name, number, filters);
     }
 
+    /**
+     * Central method to find an element on the page with filters.
+     * The number indicates the index of the desired element on the list. 
+     *
+     * @param number
+     * @param filters
+     * @return
+     */
+    public FluentWebElement $(Integer number, final Filter... filters) {
+        if (filters == null || filters.length == 0) {
+            throw new IllegalArgumentException("cssSelector or filter is required");
+        }
+        return $("*", number, filters);
+    }
 
     /**
      * return the lists corresponding to the cssSelector with it filters
@@ -382,6 +408,19 @@ public abstract class Fluent implements SearchActions {
      */
     public FluentList<FluentWebElement> find(String name, final Filter... filters) {
         return search.find(name, filters);
+    }
+    
+    /**
+     * Return the list filtered by the specified filters.
+     * 
+     * @param filters
+     * @return
+     */
+    public FluentList<FluentWebElement> find(final Filter... filters) {
+        if (filters == null || filters.length == 0) {
+            throw new IllegalArgumentException("cssSelector or filter is required");
+        }
+        return find("*", filters);
     }
 
     /**
@@ -395,6 +434,20 @@ public abstract class Fluent implements SearchActions {
     public FluentWebElement find(String name, Integer number, final Filter... filters) {
         return search.find(name, number, filters);
     }
+    
+    /**
+     * Return the element at the number position in the list filtered by the specified filters.
+     * 
+     * @param number
+     * @param filters
+     * @return
+     */
+    public FluentWebElement find(Integer number, final Filter... filters) {
+        if (filters == null || filters.length == 0) {
+            throw new IllegalArgumentException("cssSelector or filter is required");
+        }
+        return find("*", number, filters);
+    }
 
     /**
      * Return the first elements corresponding to the name and the filters
@@ -406,6 +459,19 @@ public abstract class Fluent implements SearchActions {
     public FluentWebElement findFirst(String name, final Filter... filters) {
         return search.findFirst(name, filters);
     }
+    
+    /**
+     * Return the first element corresponding to the filters.
+     *
+     * @param filters
+     * @return
+     */
+    public FluentWebElement findFirst(final Filter... filters) {
+        if (filters == null || filters.length == 0) {
+            throw new IllegalArgumentException("cssSelector or filter is required");
+        }
+        return findFirst("*", filters);
+    }
 
     /**
      * Construct a FillConstructor in order to allow easy fill
@@ -415,6 +481,19 @@ public abstract class Fluent implements SearchActions {
      */
     public FillConstructor fill(String cssSelector, Filter... filters) {
         return new FillConstructor(cssSelector, getDriver(), filters);
+    }
+    
+    /**
+     * Construct a FillConstructor with filters in order to allow easy fill.
+     * Be careful - only the visible elements are filled
+     *
+     * @param filters
+     */
+    public FillConstructor fill(Filter... filters) {
+        if (filters == null || filters.length == 0) {
+            throw new IllegalArgumentException("cssSelector or filter is required");
+        }
+        return fill("*", filters);
     }
 
     /**
@@ -436,6 +515,19 @@ public abstract class Fluent implements SearchActions {
     public FillSelectConstructor fillSelect(String cssSelector, Filter... filters) {
         return new FillSelectConstructor(cssSelector, getDriver(), filters);
     }
+    
+    /**
+     * Construct a FillSelectConstructor with filters in order to allow easy fill.
+     * Be careful - only the visible elements are filled
+     *
+     * @param filters
+     */
+    public FillSelectConstructor fillSelect(Filter... filters) {
+        if (filters == null || filters.length == 0) {
+            throw new IllegalArgumentException("cssSelector or filter is required");
+        }
+        return fillSelect("*", filters);
+    }
 
     /**
      * click all elements that are in cssSelector with its filters
@@ -446,6 +538,19 @@ public abstract class Fluent implements SearchActions {
     public Fluent click(String cssSelector, Filter... filters) {
         $(cssSelector, filters).click();
         return this;
+    }
+    
+    /**
+     * Click all elements filtered by the specified filters.
+     * Be careful - only the visible elements are clicked
+     *
+     * @param filters
+     */
+    public Fluent click(Filter... filters) {
+        if (filters == null || filters.length == 0) {
+            throw new IllegalArgumentException("cssSelector or filter is required");
+        }
+        return click("*", filters);
     }
 
     /**
@@ -458,6 +563,19 @@ public abstract class Fluent implements SearchActions {
         $(cssSelector, filters).clear();
         return this;
     }
+    
+    /**
+     * Clear texts of the all elements filtered by the specified filters.
+     * Be careful - only the visible elements are cleared
+     *
+     * @param filters
+     */
+    public Fluent clear(Filter... filters) {
+        if (filters == null || filters.length == 0) {
+            throw new IllegalArgumentException("cssSelector or filter is required");
+        }
+        return clear("*", filters);
+    }
 
     /**
      * Submit all elements that are in cssSelector with its filters
@@ -469,6 +587,19 @@ public abstract class Fluent implements SearchActions {
         $(cssSelector, filters).submit();
         return this;
     }
+    
+    /**
+     * Submit all elements filtered by the specified filters.
+     * Be careful - only the visible elements are submitted
+     *
+     * @param filters
+     */
+    public Fluent submit(Filter... filters) {
+        if (filters == null || filters.length == 0) {
+            throw new IllegalArgumentException("cssSelector or filter is required");
+        }
+        return submit("*", filters);
+    }
 
     /**
      * get a list all elements that are in cssSelector with its filters
@@ -479,6 +610,20 @@ public abstract class Fluent implements SearchActions {
      */
     public List<String> text(String cssSelector, Filter... filters) {
         return $(cssSelector, filters).getTexts();
+    }
+    
+    /**
+     * Get all texts of the elements filtered by the specified filters.
+     * Be careful - only the visible elements are submitted
+     * //TODO UTILITY ? Deprecated ?
+     *
+     * @param filters
+     */
+    public List<String> text(Filter... filters) {
+        if (filters == null || filters.length == 0) {
+            throw new IllegalArgumentException("cssSelector or filter is required");
+        }
+        return text("*", filters);
     }
 
     /**
@@ -492,6 +637,19 @@ public abstract class Fluent implements SearchActions {
         return $(cssSelector, filters).getValues();
     }
 
+    /**
+     * Get all values of the elements filtered by the specified filters.
+     * Be careful - only the visible elements are submitted
+     * //TODO UTILITY ? Deprecated ?
+     *
+     * @param filters
+     */
+    public List<String> value(Filter... filters) {
+        if (filters == null || filters.length == 0) {
+            throw new IllegalArgumentException("cssSelector or filter is required");
+        }
+        return value("*", filters);
+    }
 
     /**
      * click all elements that are in the list

--- a/fluentlenium-core/src/main/java/org/fluentlenium/core/domain/FluentList.java
+++ b/fluentlenium-core/src/main/java/org/fluentlenium/core/domain/FluentList.java
@@ -16,6 +16,7 @@ package org.fluentlenium.core.domain;
 
 import com.google.common.base.Function;
 import com.google.common.collect.Lists;
+
 import org.fluentlenium.core.action.FluentDefaultActions;
 import org.fluentlenium.core.filter.Filter;
 import org.fluentlenium.core.search.SearchActions;
@@ -276,7 +277,19 @@ public class FluentList<E extends FluentWebElement> extends ArrayList<E> impleme
         }
         return new FluentList<E>(finds);
     }
-
+    
+    /**
+     * find elements in the children with the corresponding filters
+     *
+     * @param filters
+     * @return
+     */
+    public FluentList<E> find(Filter... filters) {
+        if (filters == null || filters.length == 0) {
+            throw new IllegalArgumentException("cssSelector or filter is required");
+        }
+        return find("*", filters);
+    }
 
     /**
      * find elements into the children with the corresponding filters at the position indicated by the number
@@ -293,6 +306,20 @@ public class FluentList<E extends FluentWebElement> extends ArrayList<E> impleme
         }
         return fluentList.get(number);
     }
+    
+    /**
+     * find element in the children with the corresponding filters at the position indicated by the number
+     *
+     * @param number
+     * @param filters
+     * @return
+     */
+    public E find(Integer number, Filter... filters) {
+        if (filters == null || filters.length == 0) {
+            throw new IllegalArgumentException("cssSelector or filter is required");
+        }
+        return find("*", number, filters);
+    }
 
     /**
      * find elements into the children with the corresponding filters at the first position
@@ -303,6 +330,19 @@ public class FluentList<E extends FluentWebElement> extends ArrayList<E> impleme
      */
     public E findFirst(String name, Filter... filters) {
         return find(name, 0, filters);
+    }
+    
+    /**
+     * find element in the children with the corresponding filters at the first position
+     *
+     * @param filters
+     * @return
+     */
+    public E findFirst(Filter... filters) {
+        if (filters == null || filters.length == 0) {
+            throw new IllegalArgumentException("cssSelector or filter is required");
+        }
+        return findFirst("*", filters);
     }
 }
 

--- a/fluentlenium-core/src/main/java/org/fluentlenium/core/domain/FluentWebElement.java
+++ b/fluentlenium-core/src/main/java/org/fluentlenium/core/domain/FluentWebElement.java
@@ -195,6 +195,19 @@ public class FluentWebElement implements FluentDefaultActions<FluentWebElement>,
     public  FluentList<FluentWebElement> find(String name, Filter... filters) {
         return search.find(name, filters);
     }
+    
+    /**
+     * find elements in the children with the corresponding filters
+     *
+     * @param filters
+     * @return
+     */
+    public  FluentList<FluentWebElement> find(Filter... filters) {
+        if (filters == null || filters.length == 0) {
+            throw new IllegalArgumentException("cssSelector or filter is required");
+        }
+        return find("*", filters);
+    }
 
     /**
      * find elements into the childs with the corresponding filters at the given position
@@ -206,6 +219,20 @@ public class FluentWebElement implements FluentDefaultActions<FluentWebElement>,
     public FluentWebElement find(String name, Integer number, Filter... filters) {
         return search.find(name, number, filters);
     }
+    
+    /**
+     * find element in the children with the corresponding filters at the given position
+     * 
+     * @param number
+     * @param filters
+     * @return
+     */
+    public FluentWebElement find(Integer number, Filter... filters) {
+        if (filters == null || filters.length == 0) {
+            throw new IllegalArgumentException("cssSelector or filter is required");
+        }
+        return find("*", number, filters);
+    }
 
     /**
      * find elements into the children with the corresponding filters at the first position
@@ -216,6 +243,20 @@ public class FluentWebElement implements FluentDefaultActions<FluentWebElement>,
      */
     public FluentWebElement findFirst(String name, Filter... filters) {
         return search.findFirst(name, filters);
+    }
+    
+    /**
+     * find element in the children with the corresponding filters at the first position
+     *
+     * @param name
+     * @param filters
+     * @return
+     */
+    public FluentWebElement findFirst(Filter... filters) {
+        if (filters == null || filters.length == 0) {
+            throw new IllegalArgumentException("cssSelector or filter is required");
+        }
+        return findFirst("*", filters);
     }
 
     /**

--- a/fluentlenium-core/src/main/java/org/fluentlenium/core/wait/FluentWait.java
+++ b/fluentlenium-core/src/main/java/org/fluentlenium/core/wait/FluentWait.java
@@ -15,8 +15,10 @@ package org.fluentlenium.core.wait;
 
 
 import com.google.common.base.Function;
+
 import org.fluentlenium.core.Fluent;
 import org.fluentlenium.core.FluentPage;
+import org.fluentlenium.core.filter.Filter;
 import org.fluentlenium.core.search.Search;
 import org.openqa.selenium.Beta;
 import org.openqa.selenium.StaleElementReferenceException;
@@ -127,6 +129,27 @@ public class FluentWait implements org.openqa.selenium.support.ui.Wait<Fluent> {
     public FluentWaitMatcher until(String string) {
         updateWaitWithDefaultExceptions();
         return new FluentWaitMatcher(search, this, string);
+    }
+    
+    /**
+     * @param string - CSS selector
+     * @param filters
+     * @return
+     */
+    public FluentWaitMatcher until(String string, Filter... filters) {
+        updateWaitWithDefaultExceptions();
+        return new FluentWaitMatcher(search, this, string);
+    }
+
+    /**
+     * @param filters
+     * @return
+     */
+    public FluentWaitMatcher until(Filter... filters) {
+        if (filters == null || filters.length == 0) {
+            throw new IllegalArgumentException("cssSelector or filter is required");
+        }
+        return until("*", filters);
     }
 
     /**

--- a/fluentlenium-core/src/main/java/org/fluentlenium/core/wait/FluentWaitMatcher.java
+++ b/fluentlenium-core/src/main/java/org/fluentlenium/core/wait/FluentWaitMatcher.java
@@ -33,10 +33,15 @@ public class FluentWaitMatcher {
     private String selector;
     private FluentWait wait;
 
-    public FluentWaitMatcher(Search search, FluentWait fluentWait, String selector) {
+    public FluentWaitMatcher(Search search, FluentWait fluentWait, String selector, Filter...filters) {
         this.selector = selector;
         wait = fluentWait;
         this.search = search;
+        if (filters != null) {
+            for (Filter filter : filters) {
+                this.filters.add(filter);
+            }
+        }
     }
 
     /**

--- a/fluentlenium-core/src/test/java/org/fluentlenium/integration/FluentLeniumWaitTest.java
+++ b/fluentlenium-core/src/test/java/org/fluentlenium/integration/FluentLeniumWaitTest.java
@@ -31,6 +31,7 @@ import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.fluentlenium.core.filter.MatcherConstructor.regex;
 import static org.junit.Assert.fail;
+import static org.fluentlenium.core.filter.FilterConstructor.*;
 
 public class FluentLeniumWaitTest extends LocalFluentCase {
     @Before
@@ -297,6 +298,11 @@ public class FluentLeniumWaitTest extends LocalFluentCase {
     public void when_element_is_not_displayed_then_isPresent_return_true() {
         goTo(JAVASCRIPT_URL);
         await().atMost(1, NANOSECONDS).until("#unvisible").isPresent();
+    }
+    
+    @Test
+    public void checkAwaitWithUntilMehtodArgFilters() {
+        await().atMost(1, NANOSECONDS).until(".small", withName("name2")).hasText("Small 2");
     }
 
     @Test(expected = TimeoutException.class)

--- a/fluentlenium-core/src/test/java/org/fluentlenium/integration/JavascriptTest.java
+++ b/fluentlenium-core/src/test/java/org/fluentlenium/integration/JavascriptTest.java
@@ -120,7 +120,7 @@ public class JavascriptTest extends LocalFluentCase {
 
   @Test
   public void should_executeAsyncScript_return_String() {
-    getDriver().manage().timeouts().setScriptTimeout(100, TimeUnit.MILLISECONDS);
+    getDriver().manage().timeouts().setScriptTimeout(200, TimeUnit.MILLISECONDS);
 
     final Stopwatch stopwatch = Stopwatch.createStarted();
     final FluentJavascript fluentJavascript = executeAsyncScript(

--- a/fluentlenium-core/src/test/java/org/fluentlenium/integration/SeachOnlyWithFiltersTest.java
+++ b/fluentlenium-core/src/test/java/org/fluentlenium/integration/SeachOnlyWithFiltersTest.java
@@ -1,0 +1,164 @@
+package org.fluentlenium.integration;
+
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.fluentlenium.core.filter.FilterConstructor.*;
+
+import java.util.concurrent.TimeUnit;
+
+import org.fluentlenium.core.domain.FluentList;
+import org.fluentlenium.core.domain.FluentWebElement;
+import org.fluentlenium.integration.localtest.LocalFluentCase;
+import org.junit.Test;
+import org.openqa.selenium.support.ui.Select;
+
+public class SeachOnlyWithFiltersTest extends LocalFluentCase {
+
+    @Test
+    public void checkWithNameWorks() {
+        goTo(DEFAULT_URL);
+        FluentList list = find(withName("name"));
+        assertThat(list.getIds()).containsOnly("id");
+    }
+        
+    @Test
+    public void checkWithTextWorks() {
+        goTo(DEFAULT_URL);
+        FluentList list = find(withText("Pharmacy"));
+        assertThat(list.getIds()).containsOnly("location");
+    }
+    
+    @Test
+    public void checkWithTextStartsWithWorks() {
+        goTo(DEFAULT_URL);
+        FluentList list = find(withText().startsWith("Pharmac"));
+        assertThat(list.getIds()).containsOnly("location");
+    }
+    
+    @Test
+    public void checkIndexWorks() {
+        goTo(DEFAULT_URL);
+        FluentWebElement element = find(1, withClass("small"));
+        assertThat(element.getId()).isEqualTo("id2");
+    }
+    
+    @Test
+    public void checkFindFirstWorks() {
+        goTo(DEFAULT_URL);
+        FluentWebElement element = findFirst(withClass("small"));
+        assertThat(element.getId()).isEqualTo("id");
+    }
+    
+    @Test
+    public void checkMultipleWithWorks() {
+        goTo(DEFAULT_URL);
+        FluentList list = find(withClass("small"), withName("name"));
+        assertThat(list.getIds()).containsOnly("id");
+    }
+    
+    @Test
+    public void check$Works() {
+        goTo(DEFAULT_URL);
+        FluentList list = $(withName("name"));
+        assertThat(list.getIds()).containsOnly("id");
+    }
+    
+    @Test
+    public void check$AndIndexWorks() {
+        goTo(DEFAULT_URL);
+        FluentWebElement element = $(1, withClass("small"));
+        assertThat(element.getId()).isEqualTo("id2");
+    }
+
+    @Test
+    public void checkFillWorks() {
+        goTo(DEFAULT_URL);
+        fill(withId("name")).with("FillTest");
+        assertThat($("#name").getValue()).isEqualTo("FillTest");
+    }
+
+    @Test
+    public void checkFillSelectWorks() {
+        goTo(DEFAULT_URL);        
+        Select select = new Select(findFirst("#select").getElement());
+        assertThat(select.getFirstSelectedOption().getText()).isEqualTo("value 1");
+        fillSelect(withId("select")).withValue("value-3");
+        assertThat(select.getFirstSelectedOption().getText()).isEqualTo("value 3");        
+    }
+
+    @Test
+    public void checkClickWorks() {
+        goTo(DEFAULT_URL);
+        assertThat(title()).contains("Selenium");
+        click(withId("linkToPage2"));
+        assertThat(title()).isEqualTo("Page 2");
+    }
+
+    @Test
+    public void checkClearWorks() {
+        goTo(DEFAULT_URL);
+        assertThat($("#name").getValue()).isEqualTo("John");
+        clear(withId("name"));
+        assertThat($("#name").getValue()).isEqualTo("");
+    }
+
+    @Test
+    public void checkTextWorks() {
+        goTo(DEFAULT_URL);
+        assertThat(text(withName("name"))).containsOnly("Small 1");
+    }
+
+    @Test
+    public void checkValueWorks() {
+        goTo(DEFAULT_URL);
+        assertThat(value(withId("name"))).containsOnly("John");
+    }
+
+    @Test
+    public void checkFindChildFindWorks() {
+        goTo(DEFAULT_URL);
+        FluentList list = find(withClass("parent")).find(withClass("child"));
+        assertThat(list.getTexts()).containsOnly("Alex");
+    }
+    
+    @Test
+    public void checkFindChildFindWithIndexWorks() {
+        goTo(DEFAULT_URL);
+        FluentWebElement element = find(withClass("parent")).find(0, withClass("child"));
+        assertThat(element.getText()).isEqualTo("Alex");
+    }
+    
+    @Test
+    public void checkFindChildFindFirstWorks() {
+        goTo(DEFAULT_URL);
+        FluentWebElement element = find(withClass("parent")).findFirst(withClass("child"));
+        assertThat(element.getText()).isEqualTo("Alex");
+    }
+
+    @Test
+    public void checkFindFirstChildFindWorks() {
+        goTo(DEFAULT_URL);
+        FluentList list = findFirst(withClass("parent")).find(withClass("child"));
+        assertThat(list.getTexts()).containsOnly("Alex");
+    }
+    
+    @Test
+    public void checkFindFirstChildFindWithIndexWorks() {
+        goTo(DEFAULT_URL);
+        FluentWebElement element = findFirst(withClass("parent")).find(0, withClass("child"));
+        assertThat(element.getText()).isEqualTo("Alex");
+    }
+    
+    @Test
+    public void checkFindFirstChildFindFirstWorks() {
+        goTo(DEFAULT_URL);
+        FluentWebElement element = findFirst(withClass("parent")).findFirst(withClass("child"));
+        assertThat(element.getText()).isEqualTo("Alex");
+    }
+               
+    @Test
+    public void checkWaitWorks() {
+        goTo(DEFAULT_URL);
+        await().atMost(10, TimeUnit.NANOSECONDS).until(withClass(".small")).isPresent(); 
+    }
+}

--- a/fluentlenium-core/src/test/java/org/fluentlenium/integration/SeachOnlyWithFiltersTest.java
+++ b/fluentlenium-core/src/test/java/org/fluentlenium/integration/SeachOnlyWithFiltersTest.java
@@ -1,3 +1,17 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
 package org.fluentlenium.integration;
 
 import static java.util.concurrent.TimeUnit.NANOSECONDS;


### PR DESCRIPTION
My concerns are:
- New methods don't allow no argument "find" like `find().click()`. Users must explicitly specify "\*" like
   `find("*").click()` if they should want to click all elements.
- I added `FluentWait.until(cssSelecttor, filters)` method and `FluentWait.until(filters)` method.
   Other idea to support no cssSelector "until" method is to add `FluentWait.until()` and recommend
   to use this method like `await().until().withName("abc").isPresent();`. But I didn't adopt this idea
   since this may cause wrong usage like `await().until().isPresent();`.

I also want to change README if this PR is accepted.
