### PR TITLE
Make the test more stable

### DIFF
--- a/fluentlenium-core/src/test/java/org/fluentlenium/integration/FluentLeniumWaitTest.java
+++ b/fluentlenium-core/src/test/java/org/fluentlenium/integration/FluentLeniumWaitTest.java
@@ -302,7 +302,7 @@ public class FluentLeniumWaitTest extends LocalFluentCase {
     @Test(expected = TimeoutException.class)
     public void checkPolling() {
         goTo(JAVASCRIPT_URL);
-        await().pollingEvery(1000, TimeUnit.MILLISECONDS).until("#default").hasText("wait");
+        await().pollingEvery(1500, TimeUnit.MILLISECONDS).until("#default").hasText("wait");
     }
 
 


### PR DESCRIPTION
(Increase polling time since sometimes the polling was executed before
the text of “#default” had changed from “wait” to “wait2”, especially
on cloud CI environment.)