### PR TITLE
fix race condition test

### DIFF
--- a/fluentlenium-core/src/test/java/org/fluentlenium/integration/FluentLeniumWaitTest.java
+++ b/fluentlenium-core/src/test/java/org/fluentlenium/integration/FluentLeniumWaitTest.java
@@ -302,7 +302,7 @@ public class FluentLeniumWaitTest extends LocalFluentCase {
     @Test(expected = TimeoutException.class)
     public void checkPolling() {
         goTo(JAVASCRIPT_URL);
-        await().pollingEvery(1000, TimeUnit.MILLISECONDS).until("#default").hasText("wait");
+        await().pollingEvery(1000, TimeUnit.MILLISECONDS).until("#default").hasText("sometextThatNeverAppear");
     }
 
 


### PR DESCRIPTION
This test fails on my computers, It seems that the javascript is activated, the text "wait" appears and the ```await``` command is ok, which is not what we expected.