### PR TITLE
Recursive instantiation for @Page fields  #168

### DIFF
--- a/fluentlenium-core/src/main/java/org/fluentlenium/core/Fluent.java
+++ b/fluentlenium-core/src/main/java/org/fluentlenium/core/Fluent.java
@@ -39,6 +39,8 @@ import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.*;
 import java.net.URI;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.Set;
@@ -175,8 +177,8 @@ public abstract class Fluent implements SearchActions {
             initDriver(page, parent);
             initBaseUrl(page, parent);
 
-            //init fields with default proxies
-            Field[] fields = cls.getDeclaredFields();
+            //init fields (including superclass fields) with default proxies
+            Field[] fields = getAllFields(cls);
             for (Field fieldFromPage : fields) {
                 if (!FluentWebElement.class.isAssignableFrom(fieldFromPage.getType())) {
                     continue;
@@ -225,6 +227,14 @@ public abstract class Fluent implements SearchActions {
                 throw ex;
             }
         }
+    }
+
+    private static Field[] getAllFields(Class<?> type) {
+        List<Field> fields = new ArrayList<Field>();
+        for (Class<?> c = type; c != null; c = c.getSuperclass()) {
+            fields.addAll(Arrays.asList(c.getDeclaredFields()));
+        }
+        return fields.toArray(new Field[0]);
     }
 
     private <T extends FluentPage> void initBaseUrl(T page, Class parent) throws NoSuchMethodException, IllegalAccessException, InvocationTargetException {
@@ -380,7 +390,7 @@ public abstract class Fluent implements SearchActions {
     public FluentList<FluentWebElement> $(String name, final Filter... filters) {
         return search.find(name, filters);
     }
-    
+
     /**
      * Central methods to find elements on the page with filters.
      *
@@ -425,7 +435,7 @@ public abstract class Fluent implements SearchActions {
     public FluentList<FluentWebElement> find(String name, final Filter... filters) {
         return search.find(name, filters);
     }
-    
+
     /**
      * Return the list filtered by the specified filters.
      *
@@ -447,7 +457,7 @@ public abstract class Fluent implements SearchActions {
     public FluentWebElement find(String name, Integer number, final Filter... filters) {
         return search.find(name, number, filters);
     }
-    
+
     /**
      * Return the element at the number position in the list filtered by the specified filters.
      *
@@ -469,7 +479,7 @@ public abstract class Fluent implements SearchActions {
     public FluentWebElement findFirst(String name, final Filter... filters) {
         return search.findFirst(name, filters);
     }
-    
+
     /**
      * Return the first element corresponding to the filters.
      *
@@ -519,7 +529,7 @@ public abstract class Fluent implements SearchActions {
     public FillSelectConstructor fillSelect(String cssSelector, Filter... filters) {
         return new FillSelectConstructor(cssSelector, getDriver(), filters);
     }
-    
+
     /**
      * Construct a FillSelectConstructor with filters in order to allow easy fill.
      * Be careful - only the visible elements are filled
@@ -540,7 +550,7 @@ public abstract class Fluent implements SearchActions {
         $(cssSelector, filters).click();
         return this;
     }
-    
+
     /**
      * Click all elements filtered by the specified filters.
      * Be careful - only the visible elements are clicked
@@ -562,7 +572,7 @@ public abstract class Fluent implements SearchActions {
         $(cssSelector, filters).clear();
         return this;
     }
-    
+
     /**
      * Clear texts of the all elements filtered by the specified filters.
      * Be careful - only the visible elements are cleared
@@ -584,7 +594,7 @@ public abstract class Fluent implements SearchActions {
         $(cssSelector, filters).submit();
         return this;
     }
-    
+
     /**
      * Submit all elements filtered by the specified filters.
      * Be careful - only the visible elements are submitted
@@ -606,7 +616,7 @@ public abstract class Fluent implements SearchActions {
     public List<String> text(String cssSelector, Filter... filters) {
         return $(cssSelector, filters).getTexts();
     }
-    
+
     /**
      * Get all texts of the elements filtered by the specified filters.
      * Be careful - only the visible elements are submitted

--- a/fluentlenium-core/src/test/java/org/fluentlenium/integration/PageTest.java
+++ b/fluentlenium-core/src/test/java/org/fluentlenium/integration/PageTest.java
@@ -30,6 +30,9 @@ public class PageTest extends LocalFluentCase {
     @Page
     Page2 page2;
 
+    @Page
+    Page3 page3;
+
     @Test
     public void checkGoTo() {
         page.go();
@@ -68,6 +71,14 @@ public class PageTest extends LocalFluentCase {
         page.go();
         page.goToNextPageWithFindByClassLink();
         page2.isAt();
+    }
+
+    // Recursive instantiation for @Page fields in FluentPage::createPage #168
+    @Test
+    public void checkFieldsInitialized() {
+        page3.go();
+        assertThat(page3.linkToPage2FoundWithFindBy).isNotNull();
+        assertThat(page3.linkToPage2FoundWithFindByOnPage3).isNotNull();
     }
 }
 
@@ -109,4 +120,9 @@ class Page2 extends FluentPage {
         assertThat($("title").first().getText()).isEqualTo("Page 2");
     }
 
+}
+
+class Page3 extends PageAccueil {
+    @FindBy(css = "a.go-next")
+    FluentWebElement linkToPage2FoundWithFindByOnPage3;
 }


### PR DESCRIPTION
This simple change adds a possibility to create more robust pages. 

Example:

```java
package test;

import org.fluentlenium.core.FluentPage;
import org.fluentlenium.core.domain.FluentList;
import org.fluentlenium.core.domain.FluentWebElement;
import org.openqa.selenium.support.FindBy;

public class GooglePageBase extends FluentPage {

    @FindBy(css = "input[type='submit']")
    public FluentList<FluentWebElement> buttons;

    @Override
    public String getUrl() {
        return "https://www.google.co.uk/";
    }
}

```


```java
package test;

import org.fluentlenium.core.domain.FluentWebElement;
import org.openqa.selenium.support.FindBy;

import static org.assertj.core.api.Assertions.assertThat;

public class GooglePage extends GooglePageBase {

    @FindBy(css = "input[type='text']")
    public FluentWebElement searchField;

    @Override
    public void isAt() {
        assertThat(buttons).hasSize(2);
        assertThat(searchField).isNotNull();
    }
}
```

And the test class:

```java
package test;

import org.fluentlenium.adapter.FluentTestNg;
import org.fluentlenium.core.annotation.Page;
import org.testng.annotations.Test;

public class GoogleTest extends FluentTestNg {

    @Page
    private GooglePage googlePage;

    @Test
    public void goesTo() {
        googlePage.go();
        googlePage.isAt();
    }
}
```