### PR TITLE
Support SharedDriver.SharedType.PER_TEST for TestNG.

### DIFF
--- a/fluentlenium-core/src/main/java/org/fluentlenium/adapter/util/SharedDriver.java
+++ b/fluentlenium-core/src/main/java/org/fluentlenium/adapter/util/SharedDriver.java
@@ -26,7 +26,7 @@ import java.lang.annotation.RetentionPolicy;
 @Inherited
 @Beta
 public @interface SharedDriver {
-    public enum SharedType {ONCE, PER_CLASS, PER_METHOD}
+    public enum SharedType {ONCE, PER_CLASS, PER_METHOD, PER_TEST}
 
     /**
      * deleteCookies default : true.

--- a/fluentlenium-core/src/main/java/org/fluentlenium/adapter/util/SharedDriverHelper.java
+++ b/fluentlenium-core/src/main/java/org/fluentlenium/adapter/util/SharedDriverHelper.java
@@ -30,6 +30,11 @@ public final class SharedDriverHelper {
         return (sharedBrowser != null && sharedBrowser.type() == SharedDriver.SharedType.ONCE);
     }
 
+    public static boolean isSharedDriverPerTest(final Class<?> classe) {
+        SharedDriver sharedBrowser = classe.getAnnotation(SharedDriver.class);
+        return (sharedBrowser != null && sharedBrowser.type() == SharedDriver.SharedType.PER_TEST);
+    }
+
     public static boolean isSharedDriverPerClass(final Class<?> classe) {
         SharedDriver sharedBrowser = classe.getAnnotation(SharedDriver.class);
         return (sharedBrowser != null && sharedBrowser.type() == SharedDriver.SharedType.PER_CLASS);

--- a/fluentlenium-testng/src/main/java/org/fluentlenium/adapter/FluentTestNg.java
+++ b/fluentlenium-testng/src/main/java/org/fluentlenium/adapter/FluentTestNg.java
@@ -20,8 +20,10 @@ import org.fluentlenium.core.FluentAdapter;
 import org.openqa.selenium.WebDriver;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
+import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.BeforeTest;
 
 /**
  * All TestNG Test should extends this class. It provides default parameters.
@@ -34,6 +36,14 @@ public abstract class FluentTestNg extends FluentAdapter {
         super();
     }
 
+    @BeforeTest
+    public void beforeTest() {
+        if (SharedDriverHelper.isSharedDriverPerTest(this.getClass())) {
+            this.initFluent(getDefaultDriver()).withDefaultUrl(getDefaultBaseUrl());
+            initTest();
+        }
+    }
+    
     @BeforeClass
     public void beforeClass() {
         Class<? extends FluentTestNg> aClass = this.getClass();
@@ -54,7 +64,7 @@ public abstract class FluentTestNg extends FluentAdapter {
         }
 
     }
-
+    
     @BeforeMethod
     public void beforeMethod() {
         if (SharedDriverHelper.isSharedDriverPerMethod(this.getClass()) || SharedDriverHelper.isDefaultSharedDriver(this.getClass())) {
@@ -82,4 +92,10 @@ public abstract class FluentTestNg extends FluentAdapter {
         }
     }
 
+    @AfterTest
+    public void afterTest() {
+        if (SharedDriverHelper.isSharedDriverPerTest(this.getClass())) {
+            quit();
+        }
+    }
 }


### PR DESCRIPTION
TestNG has @BeforeTest and @AfterTest annotation, which is very useful for repeating tests with different parameter:

```xml
<?xml version='1.0' encoding='UTF-8'?> 
<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
<suite name="selenium suite">
	
	<test name="firefox tests">
		<parameter name="selenium.browser" value="firefox" />
    	<classes>
			<class name="testcases.Test_01_010"/>
		</classes>
	</test>
	
	<test name="chrome tests">
		<parameter name="selenium.browser" value="chrome" />
    	<classes>
			<class name="testcases.Test_01_010"/>
		</classes>
	</test>

</suite>
```

In the above scenario, I'd like to repeat the same tests for firefox and chrome, which can be done by declaring SharedDriver.SharedType.PER_CLASS annotation in the base test class.

