### PR TITLE
Add getTextContent method to display text content of an element

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -182,7 +182,7 @@ find(myCssSelector, 2, withName("foo")).findFirst("input", withName("bar"))
 ```
 
 ## Element
-If you need to access to the name, the id, the value, the tagname or the text of an element:
+If you need to access to the name, the id, the value, the tagname or the visible text of an element:
 
 ```java
 findFirst(myCssSelector).getName()
@@ -192,13 +192,19 @@ findFirst(myCssSelector).getTagName()
 findFirst(myCssSelector).getText()
 ```
 
+If you need to access the text content of an element, including hidden parts:
+
+```java
+findFirst(myCssSelector).getTextContent()
+```
+
 If you need to access a specific value of an attribute:
 
 ```java
 findFirst(myCssSelector).getAttribute("myCustomAttribute")
 ```
 
-You can also access a list of all the names, text, and ids of a list of elements:
+You can also access a list of all the names, visible text, and ids of a list of elements:
 ```java
 find(myCssSelector).getNames()
 find(myCssSelector).getIds()
@@ -207,7 +213,7 @@ find(myCssSelector).getAttributes("myCustomAttribute")
 find(myCssSelector).getTexts()
 ```
 
-If you want to know the name, the id, the value, the text or the value of an attribute of the first element on the list:
+If you want to know the name, the id, the value, the visible text or the value of an attribute of the first element on the list:
 ```java
 find(myCssSelector).getName()
 find(myCssSelector).getId()

--- a/fluentlenium-core/src/main/java/org/fluentlenium/core/domain/FluentList.java
+++ b/fluentlenium-core/src/main/java/org/fluentlenium/core/domain/FluentList.java
@@ -93,6 +93,13 @@ public interface FluentList<E extends FluentWebElement> extends List<E>, FluentD
     List<String> getTexts();
 
     /**
+     * Return the text contents of list elements
+     *
+     * @return list of string values
+     */
+    List<String> getTextContents();
+
+    /**
      * Return the value of the first element in the list
      *
      * @return string value

--- a/fluentlenium-core/src/main/java/org/fluentlenium/core/domain/FluentListImpl.java
+++ b/fluentlenium-core/src/main/java/org/fluentlenium/core/domain/FluentListImpl.java
@@ -183,6 +183,18 @@ public class FluentListImpl<E extends FluentWebElement> extends ArrayList<E> imp
      * {@inheritDoc}
      */
     @Override
+    public List<String> getTextContents() {
+        return Lists.transform(this, new Function<E, String>() {
+            public String apply(E webElement) {
+                return webElement.getTextContent();
+            }
+        });
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public List<String> getTexts() {
         return Lists.transform(this, new Function<E, String>() {
             public String apply(E webElement) {

--- a/fluentlenium-core/src/main/java/org/fluentlenium/core/domain/FluentWebElement.java
+++ b/fluentlenium-core/src/main/java/org/fluentlenium/core/domain/FluentWebElement.java
@@ -119,12 +119,21 @@ public class FluentWebElement implements FluentDefaultActions<FluentWebElement>,
     }
 
     /**
-     * return the text of the element
+     * return the visible text of the element
      *
      * @return text of element
      */
     public String getText() {
         return webElement.getText();
+    }
+
+    /**
+     * return the text content of the element (even invisible through textContent attribute)
+     *
+     * @return text content of element
+     */
+    public String getTextContent() {
+        return webElement.getAttribute("textContent");
     }
 
     /**

--- a/fluentlenium-core/src/test/html/index.html
+++ b/fluentlenium-core/src/test/html/index.html
@@ -45,6 +45,7 @@
 
 <span generated="true">Test custom attribute
 </span>
+<span id="hidden" style="visibility: hidden;">Hidden Text</span>
 <select id="select">
     <option value="value-1">value 1</option>
     <option value="value-2">value 2</option>

--- a/fluentlenium-core/src/test/java/org/fluentlenium/integration/HiddenTextTest.java
+++ b/fluentlenium-core/src/test/java/org/fluentlenium/integration/HiddenTextTest.java
@@ -1,0 +1,40 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package org.fluentlenium.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.fluentlenium.core.domain.FluentList;
+import org.fluentlenium.core.domain.FluentWebElement;
+import org.fluentlenium.integration.localtest.LocalFluentCase;
+import org.junit.Test;
+
+public class HiddenTextTest extends LocalFluentCase {
+
+    @Test
+    public void checkGetTextWorks() {
+        goTo(DEFAULT_URL);
+        FluentWebElement line = findFirst("#hidden");
+        assertThat(line.getText()).isEmpty();
+    }
+
+    @Test
+    public void checkGetTextContentWorks() {
+        goTo(DEFAULT_URL);
+        FluentWebElement line = findFirst("#hidden");
+        assertThat(line.getTextContent()).isEqualTo("Hidden Text");
+    }
+
+}


### PR DESCRIPTION
It can be handy to retrieve text content of an element, even if it's not visible. I use check content of a select without actually opening it (so getText() returns only empty strings ...)