### PR TITLE
Remove ThreadLocal from Fluent class

### DIFF
--- a/README.md
+++ b/README.md
@@ -810,8 +810,10 @@ Surefire maven plugin for example.
                 <artifactId>maven-surefire-plugin</artifactId>
                 <dependencies>
                     <dependency>
+                        <!-- Force a recent version of surefire-testng to avoid issues -->
                         <groupId>org.apache.maven.surefire</groupId>
                         <artifactId>surefire-testng</artifactId>
+                        <version>2.19.1</version>
                     </dependency>
                 </dependencies>
                 <configuration>

--- a/fluentlenium-core/src/main/java/org/fluentlenium/core/Fluent.java
+++ b/fluentlenium-core/src/main/java/org/fluentlenium/core/Fluent.java
@@ -36,12 +36,12 @@ import java.util.concurrent.TimeUnit;
  * Util Class which offers some shortcut to webdriver methods
  */
 public abstract class Fluent implements SearchActions<FluentWebElement> {
+    private WebDriver driver;
+    private Search search;
+
     protected enum TriggerMode {ON_FAIL, NEVER}
 
     private String baseUrl;
-
-    private ThreadLocal<WebDriver> webDriverThreadLocal = new ThreadLocal<WebDriver>();
-    private ThreadLocal<Search> searchThreadLocal = new ThreadLocal<Search>();
 
     private String htmlDumpPath;
     private String screenshotPath;
@@ -54,8 +54,8 @@ public abstract class Fluent implements SearchActions<FluentWebElement> {
     protected PageInitializer pageInitializer = new PageInitializer(this);
 
     public Fluent(WebDriver driver) {
-        this.webDriverThreadLocal.set(driver);
-        this.searchThreadLocal.set(new Search(driver));
+        this.driver = driver;
+        this.search = new Search(driver);
     }
 
     /**
@@ -198,8 +198,8 @@ public abstract class Fluent implements SearchActions<FluentWebElement> {
     }
 
     protected Fluent initFluent(WebDriver driver) {
-        this.webDriverThreadLocal.set(driver);
-        this.searchThreadLocal.set(new Search(driver));
+        this.driver = driver;
+        this.search = new Search(driver);
         if (driver instanceof EventFiringWebDriver) {
             this.events = new EventsRegistry((EventFiringWebDriver) driver);
         }
@@ -207,11 +207,11 @@ public abstract class Fluent implements SearchActions<FluentWebElement> {
     }
 
     public WebDriver getDriver() {
-        return webDriverThreadLocal.get();
+        return driver;
     }
 
     public Search getSearch() {
-        return searchThreadLocal.get();
+        return search;
     }
 
     public EventsRegistry events() {
@@ -816,12 +816,8 @@ public abstract class Fluent implements SearchActions<FluentWebElement> {
     public void quit() {
         if (getDriver() != null) {
             getDriver().quit();
+            this.driver = null;
+            this.search = null;
         }
-        cleanupDriver();
-    }
-
-    public void cleanupDriver() {
-        webDriverThreadLocal.remove();
-        searchThreadLocal.remove();
     }
 }

--- a/fluentlenium-it/pom.xml
+++ b/fluentlenium-it/pom.xml
@@ -57,6 +57,7 @@
                                         <goal>install</goal>
                                         <goal>test</goal>
                                     </goals>
+                                    <streamLogs>true</streamLogs>
                                     <properties>
                                         <it.project.version>${project.version}</it.project.version>
                                     </properties>

--- a/fluentlenium-it/src/it/testng/testng-parallel-all/pom.xml
+++ b/fluentlenium-it/src/it/testng/testng-parallel-all/pom.xml
@@ -44,6 +44,13 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.apache.maven.surefire</groupId>
+                        <artifactId>surefire-testng</artifactId>
+                        <version>2.19.1</version>
+                    </dependency>
+                </dependencies>
                 <configuration>
                     <parallel>all</parallel>
                     <threadCount>4</threadCount>

--- a/fluentlenium-it/src/it/testng/testng-parallel-classes/pom.xml
+++ b/fluentlenium-it/src/it/testng/testng-parallel-classes/pom.xml
@@ -44,6 +44,13 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.apache.maven.surefire</groupId>
+                        <artifactId>surefire-testng</artifactId>
+                        <version>2.19.1</version>
+                    </dependency>
+                </dependencies>
                 <configuration>
                     <parallel>classes</parallel>
                     <threadCount>4</threadCount>

--- a/fluentlenium-it/src/it/testng/testng-parallel-methods/pom.xml
+++ b/fluentlenium-it/src/it/testng/testng-parallel-methods/pom.xml
@@ -44,6 +44,13 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.apache.maven.surefire</groupId>
+                        <artifactId>surefire-testng</artifactId>
+                        <version>2.19.1</version>
+                    </dependency>
+                </dependencies>
                 <configuration>
                     <parallel>methods</parallel>
                     <threadCount>4</threadCount>


### PR DESCRIPTION
Those ThreadLocal were introduced as a workaround for parallel test executions with TestNG. Using a newer version of surefire-testng plugin fix the issue without using those ThreadLocal.