### PR TITLE
Add @FindBy support for default FluentPage#isAt() implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,6 +369,15 @@ public void isAt() {
 }
 ```
 
+Instead of manually implementing `isAt` method, you can use Selenium `@FindBy` (or `@FindBys`) annotation on the class
+extending [org.fluentlenium.core.FluentPage](https://github.com/FluentLenium/FluentLenium/blob/master/fluentlenium-core/src/main/java/org/fluentlenium/core/FluentPage.java)
+to define an Element Locator that should match this page and this page only.
+
+@FindBy(css="#my-page")
+public class MyPage extends FluentPage {
+   ...
+}
+
 Create your own methods to easily fill out forms, go to another or whatever else may be needed in your test.
 
 For example:

--- a/fluentlenium-core/src/main/java/org/fluentlenium/core/FluentPage.java
+++ b/fluentlenium-core/src/main/java/org/fluentlenium/core/FluentPage.java
@@ -2,13 +2,19 @@ package org.fluentlenium.core;
 
 import lombok.experimental.Delegate;
 import org.fluentlenium.core.annotation.PageUrl;
+import org.fluentlenium.core.page.PageAnnotations;
+import org.openqa.selenium.By;
+import org.openqa.selenium.NoSuchElementException;
 
 /**
  * Use the Page Object Pattern to have more resilient tests.
  */
 public abstract class FluentPage implements FluentPageControl {
 
-    protected FluentPage() {}
+    private PageAnnotations pageAnnotations = new PageAnnotations(getClass());
+
+    protected FluentPage() {
+    }
 
     protected FluentPage(FluentControl control) {
         initPage(control);
@@ -38,6 +44,14 @@ public abstract class FluentPage implements FluentPageControl {
 
     @Override
     public void isAt() {
+        By by = pageAnnotations.buildBy();
+        if (by != null) {
+            try {
+                findFirst(by);
+            } catch (NoSuchElementException e) {
+                throw new AssertionError("@FindBy element not found for page " + getClass().getName());
+            }
+        }
     }
 
     @Override

--- a/fluentlenium-core/src/main/java/org/fluentlenium/core/page/PageAnnotations.java
+++ b/fluentlenium-core/src/main/java/org/fluentlenium/core/page/PageAnnotations.java
@@ -1,0 +1,89 @@
+package org.fluentlenium.core.page;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.support.ByIdOrName;
+import org.openqa.selenium.support.CacheLookup;
+import org.openqa.selenium.support.FindAll;
+import org.openqa.selenium.support.FindBy;
+import org.openqa.selenium.support.FindBys;
+import org.openqa.selenium.support.pagefactory.AbstractAnnotations;
+
+
+/**
+ * Inspired by {@link org.openqa.selenium.support.pagefactory.Annotations}, but use a Class instead of a Field
+ * to retrieve the annotations.
+ */
+public class PageAnnotations extends AbstractAnnotations {
+    private final Class<?> cls;
+
+    /**
+     * @param cls Class expected to be a Page Object
+     */
+    public PageAnnotations(Class<?> cls) {
+        this.cls = cls;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return true if @CacheLookup annotation exists on a class
+     */
+    public boolean isLookupCached() {
+        return (cls.getAnnotation(CacheLookup.class) != null);
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Looks for one of {@link org.openqa.selenium.support.FindBy},
+     * {@link org.openqa.selenium.support.FindBys} or
+     * {@link org.openqa.selenium.support.FindAll} class annotations. In case
+     * no annotaions provided for field, returns null.
+     *
+     * @throws IllegalArgumentException when more than one annotation on a class provided
+     */
+    public By buildBy() {
+        assertValidAnnotations();
+
+        By ans = null;
+
+        FindBys findBys = cls.getAnnotation(FindBys.class);
+        if (findBys != null) {
+            ans = buildByFromFindBys(findBys);
+        }
+
+        FindAll findAll = cls.getAnnotation(FindAll.class);
+        if (ans == null && findAll != null) {
+            ans = buildBysFromFindByOneOf(findAll);
+        }
+
+        FindBy findBy = cls.getAnnotation(FindBy.class);
+        if (ans == null && findBy != null) {
+            ans = buildByFromFindBy(findBy);
+        }
+
+        return ans;
+    }
+
+    protected Class<?> getCls() {
+        return cls;
+    }
+
+    protected void assertValidAnnotations() {
+        FindBys findBys = cls.getAnnotation(FindBys.class);
+        FindAll findAll = cls.getAnnotation(FindAll.class);
+        FindBy findBy = cls.getAnnotation(FindBy.class);
+        if (findBys != null && findBy != null) {
+            throw new IllegalArgumentException("If you use a '@FindBys' annotation, " +
+                    "you must not also use a '@FindBy' annotation");
+        }
+        if (findAll != null && findBy != null) {
+            throw new IllegalArgumentException("If you use a '@FindAll' annotation, " +
+                    "you must not also use a '@FindBy' annotation");
+        }
+        if (findAll != null && findBys != null) {
+            throw new IllegalArgumentException("If you use a '@FindAll' annotation, " +
+                    "you must not also use a '@FindBys' annotation");
+        }
+    }
+}

--- a/fluentlenium-core/src/test/java/org/fluentlenium/integration/IsAtTest.java
+++ b/fluentlenium-core/src/test/java/org/fluentlenium/integration/IsAtTest.java
@@ -1,0 +1,60 @@
+package org.fluentlenium.integration;
+
+import org.assertj.core.api.ThrowableAssert;
+import org.fluentlenium.core.FluentPage;
+import org.fluentlenium.core.annotation.Page;
+import org.fluentlenium.core.annotation.PageUrl;
+import org.fluentlenium.core.domain.FluentWebElement;
+import org.fluentlenium.integration.localtest.LocalFluentCase;
+import org.junit.Test;
+import org.openqa.selenium.support.FindBy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class IsAtTest extends LocalFluentCase {
+    @FindBy(css = "#oneline")
+    public static class PageIsAt extends FluentPage {
+        @Override
+        public String getUrl() {
+            return LocalFluentCase.DEFAULT_URL;
+        }
+    }
+
+    @FindBy(css = "#invalid")
+    public static class PageIsNotAt extends FluentPage {
+        @Override
+        public String getUrl() {
+            return LocalFluentCase.DEFAULT_URL;
+        }
+    }
+
+    @Page
+    private PageIsAt pageOk;
+
+    @Page
+    private PageIsNotAt pageFail;
+
+    @Test
+    public void testIsNotAt() {
+        pageFail.go();
+
+        assertThatThrownBy(new ThrowableAssert.ThrowingCallable() {
+            @Override
+            public void call() throws Throwable {
+                pageFail.isAt();
+            }
+        }).isInstanceOf(AssertionError.class);
+
+    }
+
+    @Test
+    public void testIsAt() {
+        pageOk.go();
+        pageOk.isAt();
+    }
+
+
+
+
+}


### PR DESCRIPTION
User can now use @FindBy annotation on class of FluentPage to provide a default implementation of isAt() without actually overriding the isAt() method.

I still need to write some unit test for this.