### PR TITLE
Fixed driverLifecycle in fluentlenium.properties

### DIFF
--- a/examples/quickstart/pom.xml
+++ b/examples/quickstart/pom.xml
@@ -7,11 +7,11 @@
 
     <artifactId>fluentlenium-examples-quickstart</artifactId>
     <groupId>org.fluentlenium</groupId>
-    <version>3.1.0-SNAPSHOT</version>
+    <version>3.1.1-SNAPSHOT</version>
 
     <properties>
         <!-- Configure this property to latest available version -->
-        <fluentlenium.version>3.1.0-SNAPSHOT</fluentlenium.version>
+        <fluentlenium.version>3.1.1-SNAPSHOT</fluentlenium.version>
     </properties>
 
     <name>FluentLenium Examples Quickstart</name>

--- a/examples/spring/pom.xml
+++ b/examples/spring/pom.xml
@@ -6,13 +6,13 @@
 
     <artifactId>fluentlenium-examples-spring</artifactId>
     <groupId>org.fluentlenium</groupId>
-    <version>3.1.0-SNAPSHOT</version>
+    <version>3.1.1-SNAPSHOT</version>
 
     <name>FluentLenium Examples Spring</name>
 
     <properties>
         <!-- Configure this property to latest available version -->
-        <fluentlenium.version>3.1.0-SNAPSHOT</fluentlenium.version>
+        <fluentlenium.version>3.1.1-SNAPSHOT</fluentlenium.version>
         <selenium.version>3.0.1</selenium.version>
         <spring.version>4.2.4.RELEASE</spring.version>
     </properties>

--- a/fluentlenium-core/src/main/java/org/fluentlenium/configuration/PropertiesBackendConfiguration.java
+++ b/fluentlenium-core/src/main/java/org/fluentlenium/configuration/PropertiesBackendConfiguration.java
@@ -211,7 +211,7 @@ public class PropertiesBackendConfiguration extends BaseConfiguration implements
 
     @Override
     public DriverLifecycle getDriverLifecycle() {
-        return getEnumProperty(DriverLifecycle.class, getStringProperty("driverLifecycle"));
+        return getEnumProperty(DriverLifecycle.class, "driverLifecycle");
     }
 
     @Override


### PR DESCRIPTION
Removed getStringProperty when looking up enum value, reported in issue #461. This enables the use of fluentlenium.driverLifecycle in fluentlenium.properties.

Thanks to @thomasbem for the help with finding this bug.