### PR TITLE
Fix Page creation snippet getUrl signature

### DIFF
--- a/docs/docs.md
+++ b/docs/docs.md
@@ -433,7 +433,7 @@ For example, if I choose that the title will be sufficient to know if I'm on the
 ```java
 public class MyPage extends FluentPage {
     @Override
-    public void getUrl() {
+    public String getUrl() {
         return "/app/my-page";
     }
     


### PR DESCRIPTION
The overridden getUrl method in a page returns String instead of void as it says in the docs.