### PR TITLE
withTextContent and containingTextContent filters now work

### DIFF
--- a/fluentlenium-core/src/main/java/org/fluentlenium/core/filter/AttributeFilterPredicate.java
+++ b/fluentlenium-core/src/main/java/org/fluentlenium/core/filter/AttributeFilterPredicate.java
@@ -27,7 +27,13 @@ public class AttributeFilterPredicate implements Predicate<FluentWebElement> {
     }
 
     private String getAttributeValue(FluentWebElement element) {
-        return "text".equalsIgnoreCase(filter.getAttribut()) ? element.text() : element.attribute(filter.getAttribut());
+        if("text".equalsIgnoreCase(filter.getAttribut())) {
+            return element.text();
+        } else if("textContent".equalsIgnoreCase(filter.getAttribut())) {
+            return element.textContent();
+        } else {
+            return element.attribute(filter.getAttribut());
+        }
     }
 
 }


### PR DESCRIPTION
This fixes a bug that we ran into in our test suite. We weren't able to test this change due to unfamiliarity with the codebase.