### PR TITLE
#546: Switch parameterisation to go methods instead

### DIFF
--- a/fluentlenium-core/src/main/java/org/fluentlenium/core/FluentPage.java
+++ b/fluentlenium-core/src/main/java/org/fluentlenium/core/FluentPage.java
@@ -14,10 +14,8 @@ import org.openqa.selenium.TimeoutException;
  * <p>
  * Extend this class and use @{@link PageUrl} and @{@link org.openqa.selenium.support.FindBy} annotations to provide
  * injectable Page Objects to FluentLenium.
- *
- * @param <P> FluentPage object
  */
-public class FluentPage<P extends FluentPage> extends DefaultFluentContainer implements FluentPageControl<P> {
+public class FluentPage extends DefaultFluentContainer implements FluentPageControl {
 
     private final ClassAnnotations classAnnotations = new ClassAnnotations(getClass());
 
@@ -115,7 +113,7 @@ public class FluentPage<P extends FluentPage> extends DefaultFluentContainer imp
     }
 
     @Override
-    public final P go() {
+    public <P extends FluentPage> P go() {
         String url = getUrl();
         if (url == null) {
             throw new IllegalStateException(
@@ -126,7 +124,7 @@ public class FluentPage<P extends FluentPage> extends DefaultFluentContainer imp
     }
 
     @Override
-    public P go(Object... params) {
+    public <P extends FluentPage> P go(Object... params) {
         String url = getUrl(params);
         if (url == null) {
             throw new IllegalStateException(

--- a/fluentlenium-core/src/main/java/org/fluentlenium/core/FluentPageControl.java
+++ b/fluentlenium-core/src/main/java/org/fluentlenium/core/FluentPageControl.java
@@ -6,10 +6,8 @@ import org.fluentlenium.core.url.ParsedUrlTemplate;
  * Control a Page Object.
  *
  * @see FluentPage
- *
- * @param <P> FluentPage object
  */
-public interface FluentPageControl<P extends FluentPage> extends FluentControl {
+public interface FluentPageControl extends FluentControl {
 
     /**
      * URL of the page
@@ -45,7 +43,7 @@ public interface FluentPageControl<P extends FluentPage> extends FluentControl {
      *
      * @return <P> FluentPage object
      */
-    P go(); // NOPMD ShortMethodName
+    <P extends FluentPage> P go(); // NOPMD ShortMethodName
 
     /**
      * Got to the url defined in the page, using given parameters.
@@ -55,7 +53,7 @@ public interface FluentPageControl<P extends FluentPage> extends FluentControl {
      *
      * @return <P> FluentPage object
      */
-    P go(Object... params);
+    <P extends FluentPage> P go(Object... params);
 
     /**
      * Get the parameter values of page URL extracted from current URL.

--- a/fluentlenium-core/src/test/java/org/fluentlenium/integration/BaseUrlDynamicTest.java
+++ b/fluentlenium-core/src/test/java/org/fluentlenium/integration/BaseUrlDynamicTest.java
@@ -45,7 +45,7 @@ public class BaseUrlDynamicTest extends IntegrationFluentTest {
 }
 
 @PageUrl("/page2url.html")
-class Page2Dynamic extends FluentPage<Page2Dynamic> {
+class Page2Dynamic extends FluentPage {
     @Override
     public String getUrl() {
         return IntegrationFluentTest.PAGE_2_URL_TEST;
@@ -53,7 +53,7 @@ class Page2Dynamic extends FluentPage<Page2Dynamic> {
 }
 
 @PageUrl("?param1={param1}")
-class Page2DynamicP1 extends FluentPage<Page2DynamicP1> {
+class Page2DynamicP1 extends FluentPage {
     @Override
     public String getUrl() {
         return IntegrationFluentTest.PAGE_2_URL_TEST + super.getUrl();
@@ -66,7 +66,7 @@ class Page2DynamicP1 extends FluentPage<Page2DynamicP1> {
 }
 
 @PageUrl("?param1={param1}&param2={param2}")
-class Page2DynamicP2P1 extends FluentPage<Page2DynamicP2P1> {
+class Page2DynamicP2P1 extends FluentPage {
     @Override
     public String getUrl() {
         return IntegrationFluentTest.PAGE_2_URL_TEST + super.getUrl();

--- a/fluentlenium-core/src/test/java/org/fluentlenium/integration/PageTest.java
+++ b/fluentlenium-core/src/test/java/org/fluentlenium/integration/PageTest.java
@@ -66,7 +66,7 @@ public class PageTest extends IntegrationFluentTest {
 
     @Test
     public void checkFollowLink() {
-        page.go().goToNextPage();
+        page.<IndexPage>go().goToNextPage();
         page2.isAt();
     }
 
@@ -80,7 +80,7 @@ public class PageTest extends IntegrationFluentTest {
 
     @Test
     public void checkFollowLinkFoundWithFindBy() {
-        page.go().goToNextPageWithFindByClassLink();
+        page.<IndexPage>go().goToNextPageWithFindByClassLink();
         page2.isAt();
     }
 
@@ -160,7 +160,7 @@ public class PageTest extends IntegrationFluentTest {
     }
 }
 
-class IndexPage extends FluentPage<IndexPage> {
+class IndexPage extends FluentPage {
 
     private FluentWebElement linkToPage2;
 


### PR DESCRIPTION
As discussed, fixes for https://github.com/FluentLenium/FluentLenium/issues/546:

Move parameterisation to `go` methods instead.