### PR TITLE
#276 add FluentJUnit5 extension for JUnit5 support.

### DIFF
--- a/fluentlenium-junit/pom.xml
+++ b/fluentlenium-junit/pom.xml
@@ -24,6 +24,21 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-launcher</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.github.stephenc.jcip</groupId>
             <artifactId>jcip-annotations</artifactId>
             <scope>test</scope>

--- a/fluentlenium-junit/src/main/java/org/fluentlenium/adapter/junit/FluentJUnit5.java
+++ b/fluentlenium-junit/src/main/java/org/fluentlenium/adapter/junit/FluentJUnit5.java
@@ -1,0 +1,55 @@
+package org.fluentlenium.adapter.junit;
+
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import java.lang.reflect.Method;
+import java.util.Optional;
+
+/**
+ * FluentTest extension for JUnit 5.
+ * <p>
+ * To use this, annotate FluentTest class with @ExtendWith(FluentJUnit5.class).
+ */
+public class FluentJUnit5 implements BeforeEachCallback, AfterEachCallback, AfterAllCallback {
+    @Override
+    public void beforeEach(ExtensionContext context) throws Exception {
+        FluentTest instance = testInstanceOf(context);
+        instance._starting(testClassOf(context), testNameOf(context));
+    }
+
+    @Override
+    public void afterEach(ExtensionContext context) throws Exception {
+        FluentTest instance = testInstanceOf(context);
+        Optional<Throwable> throwable = context.getExecutionException();
+
+        if (throwable.isPresent()) {
+            instance._failed(throwable.get(), testClassOf(context), testNameOf(context));
+        } else {
+            instance._finished(testClassOf(context), testNameOf(context));
+        }
+    }
+
+    @Override
+    public void afterAll(ExtensionContext context) throws Exception {
+        FluentTest.afterClass(context.getTestClass().orElse(null));
+    }
+
+    private FluentTest testInstanceOf(ExtensionContext context) {
+        try {
+            return (FluentTest) context.getTestInstance().orElse(null);
+        } catch (ClassCastException e) {
+            throw new IllegalStateException("FluentJUnit5 can not be used other than FluentTest class.", e);
+        }
+    }
+
+    private Class testClassOf(ExtensionContext context) {
+        return context.getTestClass().orElse(null);
+    }
+
+    private String testNameOf(ExtensionContext context) {
+        return context.getTestMethod().map(Method::getName).orElse(null);
+    }
+}

--- a/fluentlenium-junit/src/main/java/org/fluentlenium/adapter/junit/FluentTest.java
+++ b/fluentlenium-junit/src/main/java/org/fluentlenium/adapter/junit/FluentTest.java
@@ -62,4 +62,17 @@ public class FluentTest extends FluentTestRunnerAdapter {
     };
     //CHECKSTYLE.ON: VisibilityModifier
 
+    // JUnit5 support, called from FluentJUnit5
+    
+    /*package*/ void _starting(Class<?> testClass, String testName) {
+        starting(testClass, testName);
+    }
+
+    /*package*/ void _finished(Class<?> testClass, String testName) {
+        finished(testClass, testName);
+    }
+
+    /*package*/ void _failed(Throwable e, Class<?> testClass, String testName) {
+        failed(e, testClass, testName);
+    }
 }

--- a/fluentlenium-junit/src/test/java/org/fluentlenium/adapter/junit/FluentJUnit5Test.java
+++ b/fluentlenium-junit/src/test/java/org/fluentlenium/adapter/junit/FluentJUnit5Test.java
@@ -1,0 +1,77 @@
+package org.fluentlenium.adapter.junit;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.*;
+
+public class FluentJUnit5Test {
+    @Mock
+    ExtensionContext context;
+
+    FluentJUnit5 sut;
+
+    static class Test1 extends FluentTest {
+        public void test1() {
+        }
+    }
+
+    private Test1 test;
+
+    @BeforeEach
+    void beforeEach() throws Exception {
+        MockitoAnnotations.initMocks(this);
+
+        sut = new FluentJUnit5();
+
+        test = spy(new Test1());
+
+        when(context.getTestInstance()).thenReturn(Optional.of(test));
+        when(context.getTestClass()).thenReturn(Optional.of(Test1.class));
+        when(context.getTestMethod()).thenReturn(Optional.of(test.getClass().getDeclaredMethod("test1")));
+    }
+
+    @Test
+    void testBeforeEach() throws Exception {
+        sut.beforeEach(context);
+
+        verify(test)._starting(eq(Test1.class), eq("test1"));
+    }
+
+    @Test
+    void testAfterEachSuccessful() throws Exception {
+        when(context.getExecutionException()).thenReturn(Optional.ofNullable(null));
+        
+        sut.afterEach(context);
+
+        verify(test)._finished(eq(Test1.class), eq("test1"));
+        verify(test, never())._failed(any(), any(), any());
+    }
+
+    @Test
+    void testAfterEachFailure() throws Exception {
+        final AssertionError error = new AssertionError("error");
+        when(context.getExecutionException()).thenReturn(Optional.of(error));
+
+        sut.afterEach(context);
+
+        verify(test)._failed(same(error), eq(Test1.class), eq("test1"));
+        verify(test, never())._finished(any(), any());
+    }
+
+    @Test
+    void badInstance() throws Exception {
+        when(context.getTestInstance()).thenReturn(Optional.of(this)); // not FluentTest
+
+        assertThrows(IllegalStateException.class, () -> sut.beforeEach(context));
+        assertThrows(IllegalStateException.class, () -> sut.afterEach(context));
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -185,6 +185,21 @@
                 <artifactId>spock-core</artifactId>
                 <version>1.0-groovy-2.4</version>
             </dependency>
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-api</artifactId>
+                <version>5.0.1</version>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-engine</artifactId>
+                <version>5.0.1</version>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.platform</groupId>
+                <artifactId>junit-platform-launcher</artifactId>
+                <version>1.0.1</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
     <build>


### PR DESCRIPTION
FluentJUnit5 class is added to support JUnit5.

You can use this to FluentTest class with @ExtendWith(FluentJUnit5.class) annotation.