### PR TITLE
Feature/#770 refactor fluent list impl

### DIFF
--- a/fluentlenium-core/src/main/java/org/fluentlenium/core/domain/FluentList.java
+++ b/fluentlenium-core/src/main/java/org/fluentlenium/core/domain/FluentList.java
@@ -1,5 +1,7 @@
 package org.fluentlenium.core.domain;
 
+import static java.util.stream.Collectors.toList;
+
 import org.fluentlenium.core.action.FluentActions;
 import org.fluentlenium.core.conditions.FluentListConditions;
 import org.fluentlenium.core.hook.HookControl;
@@ -56,7 +58,9 @@ public interface FluentList<E extends FluentWebElement>
      *
      * @return list of selenium elements
      */
-    List<WebElement> toElements();
+    default List<WebElement> toElements() {
+        return stream().map(FluentWebElement::getElement).collect(toList());
+    }
 
     /**
      * Click on all elements on the list
@@ -109,14 +113,18 @@ public interface FluentList<E extends FluentWebElement>
      *
      * @return list of string values
      */
-    List<String> values();
+    default List<String> values() {
+        return stream().map(FluentWebElement::value).collect(toList());
+    }
 
     /**
      * Return the id of elements on the list
      *
      * @return list of string values
      */
-    List<String> ids();
+    default List<String> ids() {
+        return stream().map(FluentWebElement::id).collect(toList());
+    }
 
     /**
      * Return a custom attribute of elements on the list
@@ -124,42 +132,54 @@ public interface FluentList<E extends FluentWebElement>
      * @param attribute attribute name
      * @return list of string values
      */
-    List<String> attributes(String attribute);
+    default List<String> attributes(String attribute) {
+        return stream().map(webElement -> webElement.attribute(attribute)).collect(toList());
+    }
 
     /**
      * Return the name of elements on the list
      *
      * @return list of string values
      */
-    List<String> names();
+    default List<String> names() {
+        return stream().map(FluentWebElement::name).collect(toList());
+    }
 
     /**
      * Return the Dimension of elements on the list
      *
      * @return list of Dimensions
      */
-    List<Dimension> dimensions();
+    default List<Dimension> dimensions() {
+        return stream().map(FluentWebElement::size).collect(toList());
+    }
 
     /**
      * Return the tag name of elements on the list
      *
      * @return list of string values
      */
-    List<String> tagNames();
+    default List<String> tagNames() {
+        return stream().map(FluentWebElement::tagName).collect(toList());
+    }
 
     /**
      * Return the texts of list elements
      *
      * @return list of string values
      */
-    List<String> texts();
+    default List<String> texts() {
+        return stream().map(FluentWebElement::text).collect(toList());
+    }
 
     /**
      * Return the text contents of list elements
      *
      * @return list of string values
      */
-    List<String> textContents();
+    default List<String> textContents() {
+        return stream().map(FluentWebElement::textContent).collect(toList());
+    }
 
     /**
      * find elements into the children with the corresponding filters

--- a/fluentlenium-core/src/main/java/org/fluentlenium/core/domain/FluentListImpl.java
+++ b/fluentlenium-core/src/main/java/org/fluentlenium/core/domain/FluentListImpl.java
@@ -44,10 +44,9 @@ import org.openqa.selenium.support.pagefactory.ElementLocator;
  */
 @SuppressWarnings({"PMD.GodClass", "PMD.ExcessivePublicCount"})
 public class FluentListImpl<E extends FluentWebElement> extends ComponentList<E> implements FluentList<E> {
+
     private final FluentLabelImpl<FluentList<E>> label;
-
     private final HookControlImpl<FluentList<E>> hookControl;
-
     private final FluentJavascriptActionsImpl<FluentList<E>> javascriptActions;
 
     /**
@@ -90,11 +89,6 @@ public class FluentListImpl<E extends FluentWebElement> extends ComponentList<E>
 
     private FluentJavascriptActionsImpl<FluentList<E>> getJavascriptActions() { //NOPMD UnusedPrivateMethod
         return javascriptActions;
-    }
-
-    @Override
-    public List<WebElement> toElements() {
-        return this.stream().map(FluentWebElement::getElement).collect(toList());
     }
 
     @Override
@@ -349,46 +343,6 @@ public class FluentListImpl<E extends FluentWebElement> extends ComponentList<E>
                     + " At least one element should be enabled to perform a submit.");
         }
         return this;
-    }
-
-    @Override
-    public List<String> values() {
-        return stream().map(FluentWebElement::value).collect(toList());
-    }
-
-    @Override
-    public List<String> ids() {
-        return stream().map(FluentWebElement::id).collect(toList());
-    }
-
-    @Override
-    public List<String> attributes(String attribute) {
-        return stream().map(webElement -> webElement.attribute(attribute)).collect(toList());
-    }
-
-    @Override
-    public List<String> names() {
-        return stream().map(FluentWebElement::name).collect(toList());
-    }
-
-    @Override
-    public List<Dimension> dimensions() {
-        return stream().map(FluentWebElement::size).collect(toList());
-    }
-
-    @Override
-    public List<String> tagNames() {
-        return stream().map(FluentWebElement::tagName).collect(toList());
-    }
-
-    @Override
-    public List<String> textContents() {
-        return stream().map(FluentWebElement::textContent).collect(toList());
-    }
-
-    @Override
-    public List<String> texts() {
-        return stream().map(FluentWebElement::text).collect(toList());
     }
 
     @Override

--- a/fluentlenium-core/src/main/java/org/fluentlenium/core/domain/FluentListImpl.java
+++ b/fluentlenium-core/src/main/java/org/fluentlenium/core/domain/FluentListImpl.java
@@ -257,31 +257,12 @@ public class FluentListImpl<E extends FluentWebElement> extends ComponentList<E>
 
     @Override
     public FluentList<E> clearAll() {
-        return clearAllInputs(FluentWebElement::clear);
+        return perform(FluentWebElement::clear, "clear values");
     }
 
     @Override
     public FluentList<E> clearAllReactInputs() {
-        return clearAllInputs(FluentWebElement::clearReactInput);
-    }
-
-    private FluentList<E> clearAllInputs(Consumer<E> clearInputAction) {
-        validateListIsNotEmpty();
-
-        boolean atLeastOne = false;
-        for (E fluentWebElement : this) {
-            if (fluentWebElement.enabled()) {
-                atLeastOne = true;
-                clearInputAction.accept(fluentWebElement);
-            }
-        }
-
-        if (!atLeastOne) {
-            throw new NoSuchElementException(LocatorProxies.getMessageContext(proxy) + " has no element enabled."
-                    + " At least one element should be enabled to clear values.");
-        }
-
-        return this;
+        return perform(FluentWebElement::clearReactInput, "clear values by using backspace");
     }
 
     @Override
@@ -313,21 +294,7 @@ public class FluentListImpl<E extends FluentWebElement> extends ComponentList<E>
 
     @Override
     public FluentList<E> submit() {
-        validateListIsNotEmpty();
-
-        boolean atLeastOne = false;
-        for (E fluentWebElement : this) {
-            if (fluentWebElement.enabled()) {
-                atLeastOne = true;
-                fluentWebElement.submit();
-            }
-        }
-
-        if (!atLeastOne) {
-            throw new NoSuchElementException(LocatorProxies.getMessageContext(proxy) + " has no element enabled."
-                    + " At least one element should be enabled to perform a submit.");
-        }
-        return this;
+        return perform(FluentWebElement::submit, "perform a submit");
     }
 
     @Override
@@ -451,6 +418,25 @@ public class FluentListImpl<E extends FluentWebElement> extends ComponentList<E>
             finds.addAll(filteredElementsFinder.apply(e));
         }
         return instantiator.newComponentList(getClass(), componentClass, finds);
+    }
+
+    private FluentList<E> perform(Consumer<E> action, String actionMessage) {
+        validateListIsNotEmpty();
+
+        boolean atLeastOne = false;
+        for (E fluentWebElement : this) {
+            if (fluentWebElement.enabled()) {
+                atLeastOne = true;
+                action.accept(fluentWebElement);
+            }
+        }
+
+        if (!atLeastOne) {
+            throw new NoSuchElementException(LocatorProxies.getMessageContext(proxy) + " has no element enabled."
+                    + " At least one element should be enabled to " + actionMessage + ".");
+        }
+
+        return this;
     }
 
     @Override

--- a/fluentlenium-core/src/main/java/org/fluentlenium/core/domain/FluentListImpl.java
+++ b/fluentlenium-core/src/main/java/org/fluentlenium/core/domain/FluentListImpl.java
@@ -39,9 +39,13 @@ import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.pagefactory.ElementLocator;
 
 /**
- * Map the list to a FluentList in order to offers some events like click(), submit(), value() ...
+ * Default implementation of {@link FluentList} and {@link ComponentList}.
+ * <p>
+ * It offers convenience methods to work with a collection of elements, like click(), submit(), value() ...
+ * <p>
+ * It also offers capability to add labels and hooks to an object having this type.
  *
- * @param <E> type of fluent element
+ * @param <E> type of fluent element the list contains
  */
 @SuppressWarnings({"PMD.GodClass", "PMD.ExcessivePublicCount"})
 public class FluentListImpl<E extends FluentWebElement> extends ComponentList<E> implements FluentList<E> {
@@ -88,7 +92,6 @@ public class FluentListImpl<E extends FluentWebElement> extends ComponentList<E>
     private HookControlImpl<FluentList<E>> getHookControlImpl() {
         return (HookControlImpl<FluentList<E>>) hookControl;
     }
-
 
     @Override
     public FluentWaitElementList await() {

--- a/fluentlenium-core/src/main/java/org/fluentlenium/core/domain/FluentListImpl.java
+++ b/fluentlenium-core/src/main/java/org/fluentlenium/core/domain/FluentListImpl.java
@@ -257,33 +257,22 @@ public class FluentListImpl<E extends FluentWebElement> extends ComponentList<E>
 
     @Override
     public FluentList<E> clearAll() {
-        validateListIsNotEmpty();
-
-        boolean atLeastOne = false;
-        for (E fluentWebElement : this) {
-            if (fluentWebElement.enabled()) {
-                atLeastOne = true;
-                fluentWebElement.clear();
-            }
-        }
-
-        if (!atLeastOne) {
-            throw new NoSuchElementException(LocatorProxies.getMessageContext(proxy) + " has no element enabled."
-                    + " At least one element should be enabled to clear values.");
-        }
-
-        return this;
+        return clearAllInputs(FluentWebElement::clear);
     }
 
     @Override
     public FluentList<E> clearAllReactInputs() {
+        return clearAllInputs(FluentWebElement::clearReactInput);
+    }
+
+    private FluentList<E> clearAllInputs(Consumer<E> clearInputAction) {
         validateListIsNotEmpty();
 
         boolean atLeastOne = false;
         for (E fluentWebElement : this) {
             if (fluentWebElement.enabled()) {
                 atLeastOne = true;
-                fluentWebElement.clearReactInput();
+                clearInputAction.accept(fluentWebElement);
             }
         }
 

--- a/fluentlenium-core/src/main/java/org/fluentlenium/core/domain/FluentListImpl.java
+++ b/fluentlenium-core/src/main/java/org/fluentlenium/core/domain/FluentListImpl.java
@@ -87,10 +87,6 @@ public class FluentListImpl<E extends FluentWebElement> extends ComponentList<E>
         return hookControl;
     }
 
-    private FluentJavascriptActionsImpl<FluentList<E>> getJavascriptActions() { //NOPMD UnusedPrivateMethod
-        return javascriptActions;
-    }
-
     @Override
     public FluentWaitElementList await() {
         return new FluentWaitElementList(control.await(), this);
@@ -530,7 +526,7 @@ public class FluentListImpl<E extends FluentWebElement> extends ComponentList<E>
      */
     @Override
     public FluentList<E> scrollToCenter() {
-        return getJavascriptActions().scrollToCenter();
+        return javascriptActions.scrollToCenter();
     }
 
     /**
@@ -540,7 +536,7 @@ public class FluentListImpl<E extends FluentWebElement> extends ComponentList<E>
      */
     @Override
     public FluentList<E> scrollIntoView(boolean alignWithTop) {
-        return getJavascriptActions().scrollIntoView(alignWithTop);
+        return javascriptActions.scrollIntoView(alignWithTop);
     }
 
     /**
@@ -550,7 +546,7 @@ public class FluentListImpl<E extends FluentWebElement> extends ComponentList<E>
      */
     @Override
     public FluentList<E> modifyAttribute(String attributeName, String attributeValue) {
-        return getJavascriptActions().modifyAttribute(attributeName, attributeValue);
+        return javascriptActions.modifyAttribute(attributeName, attributeValue);
     }
 
     /**
@@ -560,7 +556,7 @@ public class FluentListImpl<E extends FluentWebElement> extends ComponentList<E>
      */
     @Override
     public FluentList<E> scrollIntoView() {
-        return getJavascriptActions().scrollIntoView();
+        return javascriptActions.scrollIntoView();
     }
 }
 

--- a/fluentlenium-core/src/main/java/org/fluentlenium/core/domain/FluentListImpl.java
+++ b/fluentlenium-core/src/main/java/org/fluentlenium/core/domain/FluentListImpl.java
@@ -387,7 +387,7 @@ public class FluentListImpl<E extends FluentWebElement> extends ComponentList<E>
         }
     }
 
-    private FluentList<E> doClick(Consumer<FluentWebElement> clickAction, String clickType) {
+    private FluentList<E> doClick(Consumer<E> clickAction, String clickType) {
         validateListIsNotEmpty();
 
         boolean atLeastOne = false;

--- a/fluentlenium-core/src/main/java/org/fluentlenium/core/domain/FluentListImpl.java
+++ b/fluentlenium-core/src/main/java/org/fluentlenium/core/domain/FluentListImpl.java
@@ -45,6 +45,7 @@ import org.openqa.selenium.support.pagefactory.ElementLocator;
 @SuppressWarnings({"PMD.GodClass", "PMD.ExcessivePublicCount"})
 public class FluentListImpl<E extends FluentWebElement> extends ComponentList<E> implements FluentList<E> {
 
+    private static final Duration DEFAULT_WAIT_AND_CLICK_DURATION = Duration.ofSeconds(5);
     private final FluentLabelImpl<FluentList<E>> label;
     private final HookControlImpl<FluentList<E>> hookControl;
     private final FluentJavascriptActionsImpl<FluentList<E>> javascriptActions;
@@ -211,7 +212,7 @@ public class FluentListImpl<E extends FluentWebElement> extends ComponentList<E>
 
     @Override
     public FluentList<E> waitAndClick() {
-        return waitAndClick(Duration.ofSeconds(5));
+        return waitAndClick(DEFAULT_WAIT_AND_CLICK_DURATION);
     }
 
     @Override

--- a/fluentlenium-core/src/main/java/org/fluentlenium/core/domain/FluentListImpl.java
+++ b/fluentlenium-core/src/main/java/org/fluentlenium/core/domain/FluentListImpl.java
@@ -15,6 +15,7 @@ import java.util.function.Supplier;
 import org.fluentlenium.core.FluentControl;
 import org.fluentlenium.core.action.Fill;
 import org.fluentlenium.core.action.FillSelect;
+import org.fluentlenium.core.action.FluentJavascriptActions;
 import org.fluentlenium.core.action.FluentJavascriptActionsImpl;
 import org.fluentlenium.core.components.ComponentInstantiator;
 import org.fluentlenium.core.conditions.AtLeastOneElementConditions;
@@ -46,9 +47,9 @@ import org.openqa.selenium.support.pagefactory.ElementLocator;
 public class FluentListImpl<E extends FluentWebElement> extends ComponentList<E> implements FluentList<E> {
 
     private static final Duration DEFAULT_WAIT_AND_CLICK_DURATION = Duration.ofSeconds(5);
-    private final FluentLabelImpl<FluentList<E>> label;
-    private final HookControlImpl<FluentList<E>> hookControl;
-    private final FluentJavascriptActionsImpl<FluentList<E>> javascriptActions;
+    private final FluentLabel<FluentList<E>> label;
+    private final HookControl<FluentList<E>> hookControl;
+    private final FluentJavascriptActions<FluentList<E>> javascriptActions;
 
     /**
      * Creates a new fluent list.
@@ -80,13 +81,14 @@ public class FluentListImpl<E extends FluentWebElement> extends ComponentList<E>
         });
     }
 
-    private FluentLabel<FluentList<E>> getLabel() {
-        return label;
+    private FluentLabelImpl<FluentList<E>> getLabelImpl() {
+        return (FluentLabelImpl<FluentList<E>>) label;
     }
 
-    private HookControl<FluentList<E>> getHookControl() { //NOPMD UnusedPrivateMethod
-        return hookControl;
+    private HookControlImpl<FluentList<E>> getHookControlImpl() {
+        return (HookControlImpl<FluentList<E>>) hookControl;
     }
+
 
     @Override
     public FluentWaitElementList await() {
@@ -140,7 +142,7 @@ public class FluentListImpl<E extends FluentWebElement> extends ComponentList<E>
             configureComponentWithLabel(component);
             configureComponentWithHooks(component);
             if (component instanceof FluentWebElement) {
-                component.setHookRestoreStack(hookControl.getHookRestoreStack());
+                component.setHookRestoreStack(getHookControlImpl().getHookRestoreStack());
             }
             return component.reset().as(componentClass);
         }
@@ -372,7 +374,7 @@ public class FluentListImpl<E extends FluentWebElement> extends ComponentList<E>
 
     private void configureComponentWithHooks(E component) {
         if (component instanceof HookControl) {
-            for (HookDefinition definition : hookControl.getHookDefinitions()) {
+            for (HookDefinition definition : getHookControlImpl().getHookDefinitions()) {
                 component.withHook(definition.getHookClass(), definition.getOptions());
             }
         }
@@ -380,8 +382,8 @@ public class FluentListImpl<E extends FluentWebElement> extends ComponentList<E>
 
     private void configureComponentWithLabel(E component) {
         if (component instanceof FluentLabel) {
-            component.withLabel(label.getLabel());
-            component.withLabelHint(label.getLabelHints());
+            component.withLabel(getLabelImpl().getLabel());
+            component.withLabelHint(getLabelImpl().getLabelHints());
         }
     }
 
@@ -429,57 +431,57 @@ public class FluentListImpl<E extends FluentWebElement> extends ComponentList<E>
 
     @Override
     public FluentList<E> withLabel(String label) {
-        return getLabel().withLabel(label);
+        return this.label.withLabel(label);
     }
 
     @Override
     public FluentList<E> withLabelHint(String... labelHint) {
-        return getLabel().withLabelHint(labelHint);
+        return this.label.withLabelHint(labelHint);
     }
 
     @Override
     public FluentList<E> noHookInstance() {
-        return getHookControl().noHookInstance();
+        return hookControl.noHookInstance();
     }
 
     @Override
     public FluentList<E> noHook() {
-        return getHookControl().noHook();
+        return hookControl.noHook();
     }
 
     @Override
     public <O, H extends FluentHook<O>> FluentList<E> withHook(Class<H> hook) {
-        return getHookControl().withHook(hook);
+        return hookControl.withHook(hook);
     }
 
     @Override
     public <R> R noHook(Class<? extends FluentHook> hook, Function<FluentList<E>, R> function) {
-        return getHookControl().noHook(hook, function);
+        return hookControl.noHook(hook, function);
     }
 
     @Override
     public FluentList<E> restoreHooks() {
-        return getHookControl().restoreHooks();
+        return hookControl.restoreHooks();
     }
 
     @Override
     public <O, H extends FluentHook<O>> FluentList<E> withHook(Class<H> hook, O options) {
-        return getHookControl().withHook(hook, options);
+        return hookControl.withHook(hook, options);
     }
 
     @Override
     public FluentList<E> noHook(Class<? extends FluentHook>... hooks) {
-        return getHookControl().noHook(hooks);
+        return hookControl.noHook(hooks);
     }
 
     @Override
     public FluentList<E> noHookInstance(Class<? extends FluentHook>... hooks) {
-        return getHookControl().noHookInstance(hooks);
+        return hookControl.noHookInstance(hooks);
     }
 
     @Override
     public <R> R noHook(Function<FluentList<E>, R> function) {
-        return getHookControl().noHook(function);
+        return hookControl.noHook(function);
     }
 
     /**

--- a/fluentlenium-core/src/test/java/org/fluentlenium/core/conditions/StringConditionsImplTest.java
+++ b/fluentlenium-core/src/test/java/org/fluentlenium/core/conditions/StringConditionsImplTest.java
@@ -1,0 +1,174 @@
+package org.fluentlenium.core.conditions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+import java.util.regex.Pattern;
+
+/**
+ * Unit test for {@link StringConditionsImpl}.
+ */
+public class StringConditionsImplTest {
+
+    //contains
+
+    @Test
+    public void shouldReturnTrueIfContainsString() {
+        StringConditions stringConditions = new StringConditionsImpl("Some magical text.");
+
+        assertThat(stringConditions.contains("magical")).isTrue();
+    }
+
+    @Test
+    public void shouldReturnFalseIsNotContainsString() {
+        StringConditions stringConditions = new StringConditionsImpl("Some magical text.");
+
+        assertThat(stringConditions.contains("element")).isFalse();
+    }
+
+    @Test
+    public void shouldReturnFalseForContainsIfTargetStringIsNull() {
+        StringConditions stringConditions = new StringConditionsImpl(null);
+
+        assertThat(stringConditions.contains("magical")).isFalse();
+    }
+
+    //startsWith
+
+    @Test
+    public void shouldReturnTrueIfStartsWithString() {
+        StringConditions stringConditions = new StringConditionsImpl("Some magical text.");
+
+        assertThat(stringConditions.startsWith("Some")).isTrue();
+    }
+
+    @Test
+    public void shouldReturnFalseIsNotStartsWithString() {
+        StringConditions stringConditions = new StringConditionsImpl("Some magical text.");
+
+        assertThat(stringConditions.startsWith("magical")).isFalse();
+    }
+
+    @Test
+    public void shouldReturnFalseForStartsWithIfTargetStringIsNull() {
+        StringConditions stringConditions = new StringConditionsImpl(null);
+
+        assertThat(stringConditions.startsWith("magical")).isFalse();
+    }
+
+    //endsWith
+
+    @Test
+    public void shouldReturnTrueIfEndsWithString() {
+        StringConditions stringConditions = new StringConditionsImpl("Some magical text.");
+
+        assertThat(stringConditions.endsWith("text.")).isTrue();
+    }
+
+    @Test
+    public void shouldReturnFalseIsNotEndsWithString() {
+        StringConditions stringConditions = new StringConditionsImpl("Some magical text.");
+
+        assertThat(stringConditions.endsWith("magical")).isFalse();
+    }
+
+    @Test
+    public void shouldReturnFalseForEndsWithIfTargetStringIsNull() {
+        StringConditions stringConditions = new StringConditionsImpl(null);
+
+        assertThat(stringConditions.endsWith("magical")).isFalse();
+    }
+
+    //equalTo
+
+    @Test
+    public void shouldReturnTrueIfEqualToString() {
+        StringConditions stringConditions = new StringConditionsImpl("Some magical text.");
+
+        assertThat(stringConditions.equalTo("Some magical text.")).isTrue();
+    }
+
+    @Test
+    public void shouldReturnFalseIsNotEqualToString() {
+        StringConditions stringConditions = new StringConditionsImpl("Some magical text.");
+
+        assertThat(stringConditions.equalTo("magical")).isFalse();
+    }
+
+    @Test
+    public void shouldReturnFalseForEqualToIfTargetStringIsNull() {
+        StringConditions stringConditions = new StringConditionsImpl(null);
+
+        assertThat(stringConditions.equalTo("magical")).isFalse();
+    }
+
+    //equalToIgnoreCase
+
+    @Test
+    public void shouldReturnTrueIfEqualToIgnoreCaseString() {
+        StringConditions stringConditions = new StringConditionsImpl("Some MAGICAL text.");
+
+        assertThat(stringConditions.equalToIgnoreCase("Some magical text.")).isTrue();
+    }
+
+    @Test
+    public void shouldReturnFalseIsNotEqualToIgnoreCaseString() {
+        StringConditions stringConditions = new StringConditionsImpl("Some MAGICAL text.");
+
+        assertThat(stringConditions.equalToIgnoreCase("magical")).isFalse();
+    }
+
+    @Test
+    public void shouldReturnFalseForEqualToIgnoreCaseIfTargetStringIsNull() {
+        StringConditions stringConditions = new StringConditionsImpl(null);
+
+        assertThat(stringConditions.equalToIgnoreCase("magical")).isFalse();
+    }
+
+    //matches
+
+    @Test
+    public void shouldReturnTrueIfMatchesString() {
+        StringConditions stringConditions = new StringConditionsImpl("Some magical text.");
+
+        assertThat(stringConditions.matches("^Some .* text.$")).isTrue();
+    }
+
+    @Test
+    public void shouldReturnFalseIsNotMatchesString() {
+        StringConditions stringConditions = new StringConditionsImpl("Some MAGICAL text.");
+
+        assertThat(stringConditions.matches("magical")).isFalse();
+    }
+
+    @Test
+    public void shouldReturnFalseForMatchesStringIfTargetStringIsNull() {
+        StringConditions stringConditions = new StringConditionsImpl(null);
+
+        assertThat(stringConditions.matches("magical")).isFalse();
+    }
+
+    //matches pattern
+
+    @Test
+    public void shouldReturnTrueIfMatchesPattern() {
+        StringConditions stringConditions = new StringConditionsImpl("Some magical text.");
+
+        assertThat(stringConditions.matches(Pattern.compile("^Some .* text.$"))).isTrue();
+    }
+
+    @Test
+    public void shouldReturnFalseIsNotMatchesPattern() {
+        StringConditions stringConditions = new StringConditionsImpl("Some MAGICAL text.");
+
+        assertThat(stringConditions.matches(Pattern.compile("magical"))).isFalse();
+    }
+
+    @Test
+    public void shouldReturnFalseForMatchesPatternIfTargetStringIsNull() {
+        StringConditions stringConditions = new StringConditionsImpl(null);
+
+        assertThat(stringConditions.matches(Pattern.compile("magical"))).isFalse();
+    }
+}

--- a/fluentlenium-core/src/test/java/org/fluentlenium/core/domain/FluentListImplTest.java
+++ b/fluentlenium-core/src/test/java/org/fluentlenium/core/domain/FluentListImplTest.java
@@ -16,6 +16,7 @@ import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 
+import java.time.Duration;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -27,6 +28,9 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+/**
+ * Unit test for {@link FluentListImpl}.
+ */
 @RunWith(MockitoJUnitRunner.class)
 public class FluentListImplTest {
     @Mock
@@ -87,6 +91,35 @@ public class FluentListImplTest {
 
         assertThatThrownBy(() -> list.single()).isExactlyInstanceOf(AssertionError.class)
                 .hasMessageContaining("list should contain one element only but there are");
+    }
+
+    //count()
+
+    @Test
+    public void shouldReturnListCountWhenProxyExists() {
+        assertThat(list.count()).isEqualTo(3);
+    }
+
+    @Test
+    public void shouldReturnTrueForPresentIfListSizeIsGreaterThanZeroWhenNoLocatorHandlerIsAvailableForProxy() {
+        assertThat(list.present()).isTrue();
+    }
+
+    @Test
+    public void shouldReturnFalseForPresentIfListSizeNotGreaterThanZeroWhenNoLocatorHandlerIsAvailableForProxy() {
+        assertThat(emptyList.present()).isFalse();
+    }
+
+    //waitAndClick()
+
+    @Test
+    public void shouldThrowNoSuchElementExceptionForWaitAndClickWhenListIsEmpty() {
+        assertThatThrownBy(() -> emptyList.waitAndClick()).isInstanceOf(NoSuchElementException.class);
+    }
+
+    @Test
+    public void shouldThrowNoSuchElementExceptionForWaitAndClickSecondsWhenListIsEmpty() {
+        assertThatThrownBy(() -> emptyList.waitAndClick(Duration.ofSeconds(4))).isInstanceOf(NoSuchElementException.class);
     }
 
     @Test
@@ -208,7 +241,25 @@ public class FluentListImplTest {
         when(element3.enabled()).thenReturn(false);
 
         assertThatThrownBy(() -> list.submit()).isExactlyInstanceOf(NoSuchElementException.class).hasMessageContaining("has no element enabled");
+    }
 
+    @Test
+    public void shouldDoClear() {
+        when(element2.enabled()).thenReturn(true);
+        when(element3.enabled()).thenReturn(true);
+
+        list.clear();
+
+        verify(element1, never()).clear();
+        verify(element2).clear();
+        verify(element3).clear();
+
+        assertThatThrownBy(() -> emptyList.clear()).isExactlyInstanceOf(NoSuchElementException.class);
+
+        when(element2.enabled()).thenReturn(false);
+        when(element3.enabled()).thenReturn(false);
+
+        assertThatThrownBy(() -> list.clear()).isExactlyInstanceOf(NoSuchElementException.class).hasMessageContaining("has no element enabled");
     }
 
     @Test
@@ -247,6 +298,23 @@ public class FluentListImplTest {
         when(element3.enabled()).thenReturn(false);
 
         assertThatThrownBy(() -> list.clearAllReactInputs()).isExactlyInstanceOf(NoSuchElementException.class).hasMessageContaining("has no element enabled");
+    }
+
+    @Test
+    public void shouldClearList() {
+        list.clearList();
+
+        assertThat(((FluentListImpl<FluentWebElement>) list).getList()).hasSize(0);
+    }
+
+    @Test
+    public void shouldReturnOptionalIsListIsPresent() {
+        assertThat(list.optional()).hasValue(list);
+    }
+
+    @Test
+    public void shouldReturnEmptyOptionalIsListIsNotPresent() {
+        assertThat(emptyList.optional()).isEmpty();
     }
 
     @Test

--- a/fluentlenium-core/src/test/java/org/fluentlenium/core/domain/FluentListImplTest.java
+++ b/fluentlenium-core/src/test/java/org/fluentlenium/core/domain/FluentListImplTest.java
@@ -90,7 +90,7 @@ public class FluentListImplTest {
         assertThat(singleList.single()).isSameAs(element2);
 
         assertThatThrownBy(() -> list.single()).isExactlyInstanceOf(AssertionError.class)
-                .hasMessageContaining("list should contain one element only but there are");
+                                               .hasMessageContaining("list should contain one element only but there are");
     }
 
     //count()
@@ -163,7 +163,8 @@ public class FluentListImplTest {
         when(element2.conditions().clickable()).thenReturn(false);
         when(element3.conditions().clickable()).thenReturn(false);
 
-        assertThatThrownBy(() -> list.contextClick()).isExactlyInstanceOf(NoSuchElementException.class).hasMessageContaining("has no element clickable");
+        assertThatThrownBy(() -> list.contextClick()).isExactlyInstanceOf(NoSuchElementException.class)
+                                                     .hasMessageContaining("has no element clickable");
     }
 
     @Test
@@ -182,7 +183,8 @@ public class FluentListImplTest {
         when(element2.conditions().clickable()).thenReturn(false);
         when(element3.conditions().clickable()).thenReturn(false);
 
-        assertThatThrownBy(() -> list.contextClick()).isExactlyInstanceOf(NoSuchElementException.class).hasMessageContaining("has no element clickable");
+        assertThatThrownBy(() -> list.contextClick()).isExactlyInstanceOf(NoSuchElementException.class)
+                                                     .hasMessageContaining("has no element clickable");
     }
 
     @Test
@@ -201,7 +203,8 @@ public class FluentListImplTest {
         when(element2.conditions().clickable()).thenReturn(false);
         when(element3.conditions().clickable()).thenReturn(false);
 
-        assertThatThrownBy(() -> list.contextClick()).isExactlyInstanceOf(NoSuchElementException.class).hasMessageContaining("has no element clickable");
+        assertThatThrownBy(() -> list.contextClick()).isExactlyInstanceOf(NoSuchElementException.class)
+                                                     .hasMessageContaining("has no element clickable");
     }
 
     @Test
@@ -240,7 +243,8 @@ public class FluentListImplTest {
         when(element2.enabled()).thenReturn(false);
         when(element3.enabled()).thenReturn(false);
 
-        assertThatThrownBy(() -> list.submit()).isExactlyInstanceOf(NoSuchElementException.class).hasMessageContaining("has no element enabled");
+        assertThatThrownBy(() -> list.submit()).isExactlyInstanceOf(NoSuchElementException.class)
+                                               .hasMessageContaining("has no element enabled");
     }
 
     @Test
@@ -259,7 +263,8 @@ public class FluentListImplTest {
         when(element2.enabled()).thenReturn(false);
         when(element3.enabled()).thenReturn(false);
 
-        assertThatThrownBy(() -> list.clear()).isExactlyInstanceOf(NoSuchElementException.class).hasMessageContaining("has no element enabled");
+        assertThatThrownBy(() -> list.clear()).isExactlyInstanceOf(NoSuchElementException.class)
+                                              .hasMessageContaining("has no element enabled");
     }
 
     @Test
@@ -278,7 +283,8 @@ public class FluentListImplTest {
         when(element2.enabled()).thenReturn(false);
         when(element3.enabled()).thenReturn(false);
 
-        assertThatThrownBy(() -> list.clearAll()).isExactlyInstanceOf(NoSuchElementException.class).hasMessageContaining("has no element enabled");
+        assertThatThrownBy(() -> list.clearAll()).isExactlyInstanceOf(NoSuchElementException.class)
+                                                 .hasMessageContaining("has no element enabled");
     }
 
     @Test
@@ -297,7 +303,8 @@ public class FluentListImplTest {
         when(element2.enabled()).thenReturn(false);
         when(element3.enabled()).thenReturn(false);
 
-        assertThatThrownBy(() -> list.clearAllReactInputs()).isExactlyInstanceOf(NoSuchElementException.class).hasMessageContaining("has no element enabled");
+        assertThatThrownBy(() -> list.clearAllReactInputs()).isExactlyInstanceOf(NoSuchElementException.class)
+                                                            .hasMessageContaining("has no element enabled");
     }
 
     @Test

--- a/fluentlenium-core/src/test/java/org/fluentlenium/core/domain/FluentListImplTest.java
+++ b/fluentlenium-core/src/test/java/org/fluentlenium/core/domain/FluentListImplTest.java
@@ -32,6 +32,7 @@ import static org.mockito.Mockito.when;
  * Unit test for {@link FluentListImpl}.
  */
 @RunWith(MockitoJUnitRunner.class)
+@SuppressWarnings({"PMD.TooManyMethods", "PMD.ExcessivePublicCount"})
 public class FluentListImplTest {
     @Mock
     private FluentWebElement element1;
@@ -315,12 +316,12 @@ public class FluentListImplTest {
     }
 
     @Test
-    public void shouldReturnOptionalIsListIsPresent() {
+    public void shouldReturnOptionalIfListIsPresent() {
         assertThat(list.optional()).hasValue(list);
     }
 
     @Test
-    public void shouldReturnEmptyOptionalIsListIsNotPresent() {
+    public void shouldReturnEmptyOptionalIfListIsNotPresent() {
         assertThat(emptyList.optional()).isEmpty();
     }
 

--- a/fluentlenium-core/src/test/java/org/fluentlenium/core/domain/FluentWebElementTest.java
+++ b/fluentlenium-core/src/test/java/org/fluentlenium/core/domain/FluentWebElementTest.java
@@ -218,6 +218,12 @@ public class FluentWebElementTest {
     }
 
     @Test
+    public void shouldReturnFalseForDisplayedIfNoSuchElement() {
+        when(element.isDisplayed()).thenThrow(NoSuchElementException.class);
+        assertThat(fluentElement.displayed()).isFalse();
+    }
+
+    @Test
     public void testIsEnabled() {
         assertThat(fluentElement.enabled()).isFalse();
         when(element.isEnabled()).thenReturn(true);
@@ -225,10 +231,22 @@ public class FluentWebElementTest {
     }
 
     @Test
+    public void shouldReturnFalseForEnabledIfNoSuchElement() {
+        when(element.isEnabled()).thenThrow(NoSuchElementException.class);
+        assertThat(fluentElement.enabled()).isFalse();
+    }
+
+    @Test
     public void testIsSelected() {
         assertThat(fluentElement.selected()).isFalse();
         when(element.isSelected()).thenReturn(true);
         assertThat(fluentElement.selected()).isTrue();
+    }
+
+    @Test
+    public void shouldReturnFalseForSelectedIfNoSuchElement() {
+        when(element.isSelected()).thenThrow(NoSuchElementException.class);
+        assertThat(fluentElement.selected()).isFalse();
     }
 
     @Test
@@ -303,6 +321,11 @@ public class FluentWebElementTest {
         assertThatThrownBy(() -> fluentElement.el(By.cssSelector(".other")).now()).isInstanceOf(NoSuchElementException.class);
 
         assertThatThrownBy(() -> fluentElement.el().now()).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void shouldReturnOptionalIfElementIsPresent() {
+        assertThat(fluentElement.optional()).hasValue(fluentElement);
     }
 
     @Test


### PR DESCRIPTION
I'm going to add unit tests as well, but other than that as I see the next steps for FluentListImpl will be some API changes, like in case of scrolling I can imagine that instead of
```
elementList.scrollIntoView();
```
users could call
```
elementList.scroll().intoView();
```
where `elementList.scroll()` would return a `FluentJavascriptActionsImpl` object.