### PR TITLE
#934: Introduce hasTextContaining and hasNotTextContaining assertion methods

### DIFF
--- a/fluentlenium-assertj/src/main/java/org/fluentlenium/assertj/custom/FluentAssert.java
+++ b/fluentlenium-assertj/src/main/java/org/fluentlenium/assertj/custom/FluentAssert.java
@@ -18,11 +18,35 @@ public interface FluentAssert {
      * assertThat(element).hasText("magnificent");
      * </pre>
      * which passes when the element contains (but is not necessarily exactly equal to) the argument text.
+     * <p>
+     * NOTE: currently both this method and {@link #hasTextContaining(String)} validate text containment.
+     * If you want to validate containment please use {@link #hasTextContaining(String)}, as this method will be updated
+     * in a future release to validate equality of text(s).
      *
      * @param textToFind text to find
      * @return {@code this} assertion object.
      */
     AbstractAssert hasText(String textToFind);
+
+    /**
+     * Checks if the element, or at least one element in a list of elements, contain the text.
+     * <p>
+     * Example:
+     * <p>
+     * For a {@link org.fluentlenium.core.domain.FluentWebElement} it can be:
+     * <pre>
+     * assertThat(element).hasTextContaining("magnificent");
+     * </pre>
+     * which passes when the element contains (but is not necessarily exactly equal to) the argument text.
+     * <p>
+     * NOTE: currently both {@link #hasText(String)} and this method validate text containment. If you want to validate
+     * containment please use this method, as {@link #hasText(String)} will be updated in a future release to validate
+     * equality of text(s).
+     *
+     * @param text text to find
+     * @return {@code this} assertion object.
+     */
+    AbstractAssert hasTextContaining(String text);
 
     /**
      * Checks if the element, or at least one element in a list of elements, matches the given regex.
@@ -49,11 +73,35 @@ public interface FluentAssert {
      * assertThat(element).hasNotText("magnificent");
      * </pre>
      * which passes when the element text doesn't contains (and not when it is not equal to) to the argument text.
+     * <p>
+     * NOTE: currently both this method and {@link #hasNotTextContaining(String)} validate text containment.
+     * If you want to validate containment please use {@link #hasNotTextContaining(String)}, as this method will be updated
+     * in a future release to validate equality of text(s).
      *
      * @param textToFind text to find
      * @return {@code this} assertion object.
      */
     AbstractAssert hasNotText(String textToFind);
+
+    /**
+     * Checks if the element does not contain, or none of the elements in a list of elements contain the text.
+     * <p>
+     * Example:
+     * <p>
+     * For a {@link org.fluentlenium.core.domain.FluentWebElement} it can be:
+     * <pre>
+     * assertThat(element).hasNotText("magnificent");
+     * </pre>
+     * which passes when the element text doesn't contains (and not when it is not equal to) to the argument text.
+     * <p>
+     * NOTE: currently both {@link #hasNotText(String)} and this method validate text containment. If you want to validate
+     * containment please use this method, as {@link #hasNotText(String)} will be updated in a future release to validate
+     * equality of text(s).
+     *
+     * @param textToFind text to find
+     * @return {@code this} assertion object.
+     */
+    AbstractAssert hasNotTextContaining(String textToFind);
 
     /**
      * Checks if the element, or at least one element in a list of elements, has the given id

--- a/fluentlenium-assertj/src/main/java/org/fluentlenium/assertj/custom/FluentListAssert.java
+++ b/fluentlenium-assertj/src/main/java/org/fluentlenium/assertj/custom/FluentListAssert.java
@@ -57,6 +57,16 @@ public class FluentListAssert extends AbstractFluentAssert<FluentListAssert, Flu
     }
 
     @Override
+    public FluentListAssert hasTextContaining(String textToFind) {
+        List<String> actualTexts = requiresNonEmpty(actual.texts());
+        if (actualTexts.stream().noneMatch(text -> text.contains(textToFind))) {
+            failWithMessage("No selected elements contains text: " + textToFind
+                + ". Actual texts found: " + actualTexts);
+        }
+        return this;
+    }
+
+    @Override
     public FluentListAssert hasTextMatching(String regexToBeMatched) {
         List<String> actualTexts = requiresNonEmpty(actual.texts());
         if (actualTexts.stream().noneMatch(text -> text.matches(regexToBeMatched))) {
@@ -74,6 +84,19 @@ public class FluentListAssert extends AbstractFluentAssert<FluentListAssert, Flu
                 failWithMessage(
                         "At least one selected elements contains text: " + textToFind
                                 + ". Actual texts found: " + actualTexts);
+            }
+        }
+        return this;
+    }
+
+    @Override
+    public FluentListAssert hasNotTextContaining(String textToFind) {
+        List<String> actualTexts = requiresNonEmpty(actual.texts());
+        for (String text : actualTexts) {
+            if (text.contains(textToFind)) {
+                failWithMessage(
+                    "At least one selected elements contains text: " + textToFind
+                        + ". Actual texts found: " + actualTexts);
             }
         }
         return this;

--- a/fluentlenium-assertj/src/main/java/org/fluentlenium/assertj/custom/FluentWebElementAssert.java
+++ b/fluentlenium-assertj/src/main/java/org/fluentlenium/assertj/custom/FluentWebElementAssert.java
@@ -95,6 +95,16 @@ public class FluentWebElementAssert extends AbstractFluentAssert<FluentWebElemen
     }
 
     @Override
+    public FluentWebElementAssert hasTextContaining(String text) {
+        String actualText = actual.text();
+        if (!actualText.contains(text)) {
+            failWithMessage("The element does not contain the text: " + text
+                + ". Actual text found : " + actualText);
+        }
+        return this;
+    }
+
+    @Override
     public FluentWebElementAssert hasTextMatching(String regexToBeMatched) {
         String actualText = actual.text();
         if (!actualText.matches(regexToBeMatched)) {
@@ -106,6 +116,14 @@ public class FluentWebElementAssert extends AbstractFluentAssert<FluentWebElemen
 
     @Override
     public FluentWebElementAssert hasNotText(String textToFind) {
+        if (actual.text().contains(textToFind)) {
+            failWithMessage("The element contains the text: " + textToFind);
+        }
+        return this;
+    }
+
+    @Override
+    public FluentWebElementAssert hasNotTextContaining(String textToFind) {
         if (actual.text().contains(textToFind)) {
             failWithMessage("The element contains the text: " + textToFind);
         }

--- a/fluentlenium-assertj/src/test/java/org/fluentlenium/assertj/custom/FluentListAssertTest.java
+++ b/fluentlenium-assertj/src/test/java/org/fluentlenium/assertj/custom/FluentListAssertTest.java
@@ -43,8 +43,22 @@ public class FluentListAssertTest {
     public void testHasTextKo() {
         when(fluentList.texts()).thenReturn(Lists.newArrayList("some text", "other text"));
         assertThatAssertionErrorIsThrownBy(() -> listAssert.hasText("absent text"))
-                .hasMessage("No selected elements contains text: absent text. "
-                        + "Actual texts found: [some text, other text]");
+            .hasMessage("No selected elements contains text: absent text. "
+                + "Actual texts found: [some text, other text]");
+    }
+
+    @Test
+    public void testHasTextContainingOk() {
+        when(fluentList.texts()).thenReturn(singletonList("some text to contain"));
+        listAssert.hasTextContaining("some text");
+    }
+
+    @Test
+    public void testHasTextContainingKo() {
+        when(fluentList.texts()).thenReturn(Lists.newArrayList("some text to contain", "other text to contain"));
+        assertThatAssertionErrorIsThrownBy(() -> listAssert.hasTextContaining("absent text"))
+            .hasMessage("No selected elements contains text: absent text. "
+                + "Actual texts found: [some text to contain, other text to contain]");
     }
 
     @Test
@@ -71,8 +85,22 @@ public class FluentListAssertTest {
     public void testHasNotTextKo() {
         when(fluentList.texts()).thenReturn(Lists.newArrayList("some text", "other text"));
         assertThatAssertionErrorIsThrownBy(() -> listAssert.hasNotText("other text"))
-                .hasMessage("At least one selected elements contains text: other text. "
-                        + "Actual texts found: [some text, other text]");
+            .hasMessage("At least one selected elements contains text: other text. "
+                + "Actual texts found: [some text, other text]");
+    }
+
+    @Test
+    public void testHasNotTextContainingOk() {
+        when(fluentList.texts()).thenReturn(singletonList("other text"));
+        listAssert.hasNotTextContaining("some text");
+    }
+
+    @Test
+    public void testHasNotTextContainingKo() {
+        when(fluentList.texts()).thenReturn(Lists.newArrayList("some text", "other text to contain"));
+        assertThatAssertionErrorIsThrownBy(() -> listAssert.hasNotTextContaining("other text"))
+            .hasMessage("At least one selected elements contains text: other text. "
+                + "Actual texts found: [some text, other text to contain]");
     }
 
     @Test

--- a/fluentlenium-assertj/src/test/java/org/fluentlenium/assertj/custom/FluentWebElementAssertTest.java
+++ b/fluentlenium-assertj/src/test/java/org/fluentlenium/assertj/custom/FluentWebElementAssertTest.java
@@ -17,7 +17,7 @@ import static org.mockito.Mockito.when;
 /**
  * Unit test for {@link FluentWebElementAssert}.
  */
-public class FluentWebElementTest {
+public class FluentWebElementAssertTest {
     @Mock
     private FluentWebElement element;
     private FluentWebElementAssert elementAssert;
@@ -354,7 +354,7 @@ public class FluentWebElementTest {
     }
 
     @Test
-    public void testSubstringKo() {
+    public void testHasClassSubstringKo() {
         when(element.attribute("class")).thenReturn("yolokitten");
         assertThatAssertionErrorIsThrownBy(() -> elementAssert.hasClass("yolo"))
                 .hasMessage("The element does not have the class: yolo. Actual class found : yolokitten");
@@ -364,6 +364,12 @@ public class FluentWebElementTest {
     public void testHasTextOk() {
         when(element.text()).thenReturn("There is a 5% increase");
         elementAssert.hasText("There is a 5% increase");
+    }
+
+    @Test
+    public void testHasTextContainingOk() {
+        when(element.text()).thenReturn("There is a 5% increase");
+        elementAssert.hasTextContaining("There is a 5%");
     }
 
     @Test
@@ -394,6 +400,26 @@ public class FluentWebElementTest {
     }
 
     @Test
+    public void testHasNotTextContainingPositive() {
+        when(element.text()).thenReturn("Something");
+        elementAssert.hasNotTextContaining("Text which isn't above");
+    }
+
+    @Test
+    public void testHasNotTextContainingNegative() {
+        when(element.text()).thenReturn("Something written here");
+        assertThatAssertionErrorIsThrownBy(() -> elementAssert.hasNotTextContaining("Something"))
+            .hasMessage("The element contains the text: Something");
+    }
+
+    @Test
+    public void testHasTextContainingWithSpecialCharactersInElement() {
+        String textWithStringFormatError = "%A";
+        when(element.text()).thenReturn(textWithStringFormatError);
+        elementAssert.hasTextContaining(textWithStringFormatError);
+    }
+
+    @Test
     public void testHasTextWithSpecialCharactersInElement() {
         String textWithStringFormatError = "%A";
         when(element.text()).thenReturn(textWithStringFormatError);
@@ -409,6 +435,21 @@ public class FluentWebElementTest {
 
         try {
             elementAssert.hasText(textToFind);
+            fail("Expected assertion error");
+        } catch (AssertionError assertionError) {
+            assertThat(assertionError.getMessage()).contains("Actual text found : " + firstActualText);
+        }
+    }
+
+    @Test
+    public void testHasNoRaceConditionInHasTextContaining() {
+        String textToFind = "someText";
+        String firstActualText = "someOtherText";
+
+        when(element.text()).thenReturn(firstActualText, textToFind);
+
+        try {
+            elementAssert.hasTextContaining(textToFind);
             fail("Expected assertion error");
         } catch (AssertionError assertionError) {
             assertThat(assertionError.getMessage()).contains("Actual text found : " + firstActualText);


### PR DESCRIPTION
For now I basically duplicated/copied the logic of hasText and hasNotText into hasTextContaining and hasNotTextContaining respectively. Later when hasText will be changed to validate text equality, they can be deduplicated properly.