### PR TITLE
upgrade maven-javadoc-plugin during releases

### DIFF
--- a/fluentlenium-kotest-assertions/pom.xml
+++ b/fluentlenium-kotest-assertions/pom.xml
@@ -14,6 +14,7 @@
     <properties>
         <kotlin.version>1.5.10</kotlin.version>
         <kotest.version>4.6.0</kotest.version>
+        <dokka.version>1.4.32</dokka.version>
     </properties>
 
     <dependencyManagement>
@@ -134,4 +135,36 @@
         </plugins>
     </build>
 
+    <profiles>
+        <profile>
+            <id>sonatype-oss-release</id>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.jetbrains.dokka</groupId>
+                        <artifactId>dokka-maven-plugin</artifactId>
+                        <version>${dokka.version}</version>
+                        <executions>
+                            <execution>
+                                <phase>prepare-package</phase>
+                                <goals>
+                                    <goal>javadocJar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <dokkaPlugins>
+                                <plugin>
+                                    <groupId>org.jetbrains.dokka</groupId>
+                                    <artifactId>kotlin-as-java-plugin</artifactId>
+                                    <version>${dokka.version}</version>
+                                </plugin>
+                            </dokkaPlugins>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/fluentlenium-kotest-assertions/pom.xml
+++ b/fluentlenium-kotest-assertions/pom.xml
@@ -147,7 +147,7 @@
                         <version>${dokka.version}</version>
                         <executions>
                             <execution>
-                                <phase>prepare-package</phase>
+                                <phase>package</phase>
                                 <goals>
                                     <goal>javadocJar</goal>
                                 </goals>

--- a/fluentlenium-kotest/pom.xml
+++ b/fluentlenium-kotest/pom.xml
@@ -135,7 +135,7 @@
                         <version>${dokka.version}</version>
                         <executions>
                             <execution>
-                                <phase>prepare-package</phase>
+                                <phase>package</phase>
                                 <goals>
                                     <goal>javadocJar</goal>
                                 </goals>

--- a/fluentlenium-kotest/pom.xml
+++ b/fluentlenium-kotest/pom.xml
@@ -14,6 +14,7 @@
     <properties>
         <kotlin.version>1.5.10</kotlin.version>
         <kotest.version>4.6.0</kotest.version>
+        <dokka.version>1.4.32</dokka.version>
     </properties>
 
     <dependencyManagement>
@@ -121,5 +122,38 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>sonatype-oss-release</id>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.jetbrains.dokka</groupId>
+                        <artifactId>dokka-maven-plugin</artifactId>
+                        <version>${dokka.version}</version>
+                        <executions>
+                            <execution>
+                                <phase>prepare-package</phase>
+                                <goals>
+                                    <goal>javadocJar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <dokkaPlugins>
+                                <plugin>
+                                    <groupId>org.jetbrains.dokka</groupId>
+                                    <artifactId>kotlin-as-java-plugin</artifactId>
+                                    <version>${dokka.version}</version>
+                                </plugin>
+                            </dokkaPlugins>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -684,6 +684,20 @@
                 </plugins>
             </build>
         </profile>
+
+        <profile>
+            <id>sonatype-oss-release</id>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>3.3.0</version>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 
 </project>


### PR DESCRIPTION
related to https://github.com/FluentLenium/FluentLenium/issues/1250

this is a workaround for the issues encountered during release: https://github.com/FluentLenium/FluentLenium/issues/1250#issuecomment-859560799

the maven-javadoc-plugin is upgraded to a recent version
Additionally the maven dokka plugin is enabled so that a javadoc jar is created for the kotlin submodules.
