### PR TITLE
allow to provide a custom WebDriver instance per test

### DIFF
--- a/fluentlenium-kotest/src/main/kotlin/org/fluentlenium/adapter/kotest/internal/KoTestFluentAdapter.kt
+++ b/fluentlenium-kotest/src/main/kotlin/org/fluentlenium/adapter/kotest/internal/KoTestFluentAdapter.kt
@@ -68,11 +68,14 @@ internal class KoTestFluentAdapter constructor(var useConfigurationOverride: () 
 
             currentTestName.set(testName)
 
+            val theTestInstance =
+                testCase.spec as? IFluentAdapter ?: throw IllegalArgumentException()
+
             val driver =
                 getTestDriver(
                     testCase.spec.javaClass,
                     testName,
-                    ::newWebDriver,
+                    theTestInstance::newWebDriver,
                     thisListener::failed,
                     configuration,
                     sharedMutator.getEffectiveParameters(testClass, testName, driverLifecycle)

--- a/fluentlenium-kotest/src/test/kotlin/org/fluentlenium/adapter/kotest/describespec/CanProvideCustomWebDriverSpec.kt
+++ b/fluentlenium-kotest/src/test/kotlin/org/fluentlenium/adapter/kotest/describespec/CanProvideCustomWebDriverSpec.kt
@@ -1,0 +1,24 @@
+package org.fluentlenium.adapter.kotest.describespec
+
+import io.kotest.matchers.shouldBe
+import org.fluentlenium.adapter.kotest.FluentDescribeSpec
+import org.fluentlenium.adapter.kotest.TestConstants.DEFAULT_URL
+import org.openqa.selenium.WebDriver
+
+class CanProvideCustomWebDriverSpec : FluentDescribeSpec() {
+
+    var createCount = 0
+
+    override fun newWebDriver(): WebDriver {
+        createCount++
+        return super.newWebDriver()
+    }
+
+    init {
+        it("we can provide a custom WebDriver by overriding a method") {
+            goTo(DEFAULT_URL)
+
+            createCount shouldBe 1
+        }
+    }
+}


### PR DESCRIPTION
this i a bugfix for the Kotest integration.

We need to delegate the `newWebDriver` call back to the testinstance to ensure that a overridden method is actually used.