### PR TITLE
add another example that shows how to use fluentlenium with docker

### DIFF
--- a/examples/kotest/build.gradle.kts
+++ b/examples/kotest/build.gradle.kts
@@ -29,8 +29,9 @@ tasks.withType<Test>().configureEach {
 
 dependencies {
     implementation(kotlin("stdlib-jdk8"))
-    testImplementation("org.fluentlenium:fluentlenium-kotest:4.8.1-SNAPSHOT")
-    testImplementation("org.fluentlenium:fluentlenium-kotest-assertions:4.8.1-SNAPSHOT")
+    val fluentleniumVersion = "4.8.1-SNAPSHOT"
+    testImplementation("org.fluentlenium:fluentlenium-kotest:$fluentleniumVersion")
+    testImplementation("org.fluentlenium:fluentlenium-kotest-assertions:$fluentleniumVersion")
 
     val koTestVersion = "4.6.0"
     testImplementation("io.kotest:kotest-runner-junit5:$koTestVersion")
@@ -39,4 +40,9 @@ dependencies {
     testImplementation("io.github.bonigarcia:webdrivermanager:4.4.3")
     testImplementation("org.seleniumhq.selenium:selenium-api:3.141.59")
     testImplementation("org.seleniumhq.selenium:selenium-chrome-driver:3.141.59")
+
+    testImplementation("io.kotest.extensions:kotest-extensions-testcontainers:1.0.0")
+    testImplementation("org.testcontainers:selenium:1.15.3")
+
+    testImplementation("ch.qos.logback:logback-classic:1.2.3")
 }

--- a/examples/kotest/src/test/kotlin/org/fluentlenium/example/kotest/VideoRecordingSpec.kt
+++ b/examples/kotest/src/test/kotlin/org/fluentlenium/example/kotest/VideoRecordingSpec.kt
@@ -1,0 +1,70 @@
+package org.fluentlenium.example.kotest
+
+import io.kotest.core.listeners.TestListener
+import io.kotest.core.spec.Spec
+import io.kotest.extensions.testcontainers.perTest
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import org.fluentlenium.adapter.kotest.FluentFreeSpec
+import org.openqa.selenium.WebDriver
+import org.openqa.selenium.chrome.ChromeOptions
+import org.testcontainers.containers.BrowserWebDriverContainer
+import org.testcontainers.containers.VncRecordingContainer
+import java.io.File
+
+/**
+ * This test demonstrates how to use Fluentlenium in combination with a Docker/Chrome container that hosts the browser.
+ */
+class VideoRecordingSpec : FluentFreeSpec() {
+
+    private val SEARCH_TEXT = "FluentLenium"
+
+    /**
+     * directory to save the videos to
+     */
+    private val videoDirectory = File("build/videos")
+
+    /**
+     * start Browser inside Docker container that is also capable of recrding videos
+     * https://www.testcontainers.org/modules/webdriver_containers/
+     */
+    private val dockerChrome = BrowserWebDriverContainer<Nothing>().apply {
+        // this is a workaround to avoid kotlin/generics issue:
+        // https://github.com/testcontainers/testcontainers-java/issues/318
+
+        withCapabilities(ChromeOptions())
+        withRecordingMode(
+            BrowserWebDriverContainer.VncRecordingMode.RECORD_ALL,
+            videoDirectory,
+            VncRecordingContainer.VncRecordingFormat.MP4
+        )
+    }
+
+    /**
+     * use the Kotest testcontainers extension so Kotest can manage the lifeccycle of the docker container.
+     *
+     * https://kotest.io/docs/extensions/test_containers.html
+     */
+    override fun listeners(): List<TestListener> =
+        listOf(dockerChrome.perTest())
+
+    override fun newWebDriver(): WebDriver =
+        dockerChrome.webDriver
+
+    override fun beforeSpec(spec: Spec) {
+        videoDirectory.mkdirs()
+        videoDirectory.exists() shouldBe true
+    }
+
+    init {
+        "Title of duck duck go" {
+            goTo("https://duckduckgo.com")
+
+            el("#search_form_input_homepage").fill().with(SEARCH_TEXT)
+            el("#search_button_homepage").submit()
+            await().untilWindow(SEARCH_TEXT)
+
+            window().title() shouldContain SEARCH_TEXT
+        }
+    }
+}

--- a/examples/kotest/src/test/resources/logback-test.xml
+++ b/examples/kotest/src/test/resources/logback-test.xml
@@ -1,0 +1,14 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>


### PR DESCRIPTION
this adds an example that shows how to setup a Kotest/Fluentlenium test that uses a Docker/Chrome container to run the browser.