### PR TITLE
limit Coveralls report to own repo

### DIFF
--- a/.github/workflows/build-workflow.yml
+++ b/.github/workflows/build-workflow.yml
@@ -33,7 +33,7 @@ jobs:
       run: |
         mvn -B -Pjava11 clean verify jacoco:report --file pom.xml -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
     - name: Coveralls report
-      if: github.ref == 'refs/heads/develop'
+      if: github.event.pull_request.head.repo.full_name == github.repository
       env:
         REPO_TOKEN: ${{ secrets.REPO_TOKEN }}
       run: |

--- a/.github/workflows/build-workflow.yml
+++ b/.github/workflows/build-workflow.yml
@@ -30,10 +30,13 @@ jobs:
       with:
         java-version: 11
     - name: Java 11 - unit & integration tests code coverage
+      run: |
+        mvn -B -Pjava11 clean verify jacoco:report --file pom.xml -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+    - name: Coveralls report
+      if: github.ref == 'refs/heads/develop'
       env:
         REPO_TOKEN: ${{ secrets.REPO_TOKEN }}
       run: |
-        mvn -B -Pjava11 clean verify jacoco:report --file pom.xml -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
         mvn -Pjava11 -DrepoToken=$REPO_TOKEN coveralls:report --file pom.xml
 
   java11-parallelism-tests:


### PR DESCRIPTION
currently some of the github actions are failing PR builds in forked repos.

this tries to limit some of these actions to be only run when the feature branch is in the original repo