### PR TITLE
don't run Coverall in fork

### DIFF
--- a/.github/workflows/build-workflow.yml
+++ b/.github/workflows/build-workflow.yml
@@ -10,6 +10,14 @@ on:
     branches: [ develop ]
 
 jobs:
+  dump:
+    runs-on: ubuntu-latest
+    steps:
+      - name: print context
+        env:
+          GITHUB_CONTEXT: ${{ toJSON(github) }}
+        run: echo "$GITHUB_CONTEXT"
+
   java8-build:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build-workflow.yml
+++ b/.github/workflows/build-workflow.yml
@@ -9,7 +9,18 @@ on:
   pull_request:
     branches: [ develop ]
 
+env:
+  MAVEN_OPTS: "-Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
+
 jobs:
+  dump:
+    runs-on: ubuntu-latest
+    steps:
+      - name: print context
+        env:
+          GITHUB_CONTEXT: ${{ toJSON(github) }}
+        run: echo "$GITHUB_CONTEXT"
+
   java8-build:
     runs-on: ubuntu-latest
     steps:
@@ -19,7 +30,7 @@ jobs:
       with:
         java-version: 1.8
     - name: Java 8 - unit & integration tests
-      run: mvn -B -Pjava8 clean verify --file pom.xml -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+      run: mvn -B -Pjava8 clean verify --file pom.xml
 
   java11-build:
     runs-on: ubuntu-latest
@@ -31,13 +42,14 @@ jobs:
         java-version: 11
     - name: Java 11 - unit & integration tests code coverage
       run: |
-        mvn -B -Pjava11 clean verify jacoco:report --file pom.xml -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+        echo "disabled"
+#        mvn -B -Pjava11 clean verify jacoco:report --file pom.xml
     - name: Coveralls report
       if: github.repository == 'FluentLenium/FluentLenium'
       env:
         REPO_TOKEN: ${{ secrets.REPO_TOKEN }}
       run: |
-        mvn -Pjava11 -DrepoToken=$REPO_TOKEN coveralls:report --file pom.xml
+        mvn -B -Pjava11 -DrepoToken=$REPO_TOKEN coveralls:report --file pom.xml
 
   java11-parallelism-tests:
     runs-on: ubuntu-latest
@@ -48,7 +60,7 @@ jobs:
         with:
           java-version: 11
       - name: Java 11 - unit & integration tests
-        run: mvn -B -Pframework-integration-tests,java11 -pl '!fluentlenium-integration-tests,!fluentlenium-cucumber,!fluentlenium-spock,!fluentlenium-coverage-report,!fluentlenium-spring-testng' clean test --file pom.xml -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dtest=*/it/* -DfailIfNoTests=false -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+        run: mvn -B -Pframework-integration-tests,java11 -pl '!fluentlenium-integration-tests,!fluentlenium-cucumber,!fluentlenium-spock,!fluentlenium-coverage-report,!fluentlenium-spring-testng' clean test --file pom.xml -Dtest=*/it/* -DfailIfNoTests=false
 
   java11-javadoc:
     runs-on: ubuntu-latest
@@ -59,7 +71,7 @@ jobs:
       with:
         java-version: 11
     - name: Java 11 - JavaDoc
-      run: mvn -Pjava11 javadoc:aggregate -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
+      run: mvn -Pjava11 javadoc:aggregate
 
   compile-gradle-example:
     runs-on: ubuntu-latest
@@ -85,4 +97,4 @@ jobs:
       - name: Install Fluentlenium
         uses: ./.github/actions/fluentlenium-maven-install
       - name: Compile maven examples
-        run: mvn -nsu -Pexamples clean compile -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
+        run: mvn -nsu -Pexamples clean compile

--- a/.github/workflows/build-workflow.yml
+++ b/.github/workflows/build-workflow.yml
@@ -5,18 +5,11 @@ name: Java pipeline
 
 on:
   push:
+    branches: [ develop ]
   pull_request:
     branches: [ develop ]
 
 jobs:
-  dump:
-    runs-on: ubuntu-latest
-    steps:
-      - name: print context
-        env:
-          GITHUB_CONTEXT: ${{ toJSON(github) }}
-        run: echo "$GITHUB_CONTEXT"
-
   java8-build:
     runs-on: ubuntu-latest
     steps:
@@ -40,7 +33,7 @@ jobs:
       run: |
         mvn -B -Pjava11 clean verify jacoco:report --file pom.xml -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
     - name: Coveralls report
-      if: github.event.pull_request.head.repo.full_name == github.repository
+      if: github.repository == 'FluentLenium/FluentLenium'
       env:
         REPO_TOKEN: ${{ secrets.REPO_TOKEN }}
       run: |

--- a/.github/workflows/build-workflow.yml
+++ b/.github/workflows/build-workflow.yml
@@ -5,7 +5,6 @@ name: Java pipeline
 
 on:
   push:
-    branches: [ develop ]
   pull_request:
     branches: [ develop ]
 

--- a/.github/workflows/build-workflow.yml
+++ b/.github/workflows/build-workflow.yml
@@ -13,14 +13,6 @@ env:
   MAVEN_OPTS: "-Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
 
 jobs:
-  dump:
-    runs-on: ubuntu-latest
-    steps:
-      - name: print context
-        env:
-          GITHUB_CONTEXT: ${{ toJSON(github) }}
-        run: echo "$GITHUB_CONTEXT"
-
   java8-build:
     runs-on: ubuntu-latest
     steps:
@@ -42,8 +34,7 @@ jobs:
         java-version: 11
     - name: Java 11 - unit & integration tests code coverage
       run: |
-        echo "disabled"
-#        mvn -B -Pjava11 clean verify jacoco:report --file pom.xml
+        mvn -B -Pjava11 clean verify jacoco:report --file pom.xml
     - name: Coveralls report
       if: ${{ (github.repository == 'FluentLenium/FluentLenium' && github.event_name == 'push') || (github.event.pull_request.head.repo.full_name == github.repository) }}
       env:

--- a/.github/workflows/build-workflow.yml
+++ b/.github/workflows/build-workflow.yml
@@ -45,7 +45,7 @@ jobs:
         echo "disabled"
 #        mvn -B -Pjava11 clean verify jacoco:report --file pom.xml
     - name: Coveralls report
-      if: github.repository == 'FluentLenium/FluentLenium'
+      if: ${{ (github.repository == 'FluentLenium/FluentLenium' && github.event_name == 'push') || (github.event.pull_request.head.repo.full_name == github.repository) }}
       env:
         REPO_TOKEN: ${{ secrets.REPO_TOKEN }}
       run: |


### PR DESCRIPTION
this changes the condition to check whether coverall should be run or not.

The idea is to _not_ run it in forks as they don't have the necessary secrets.
The condition is used previously was not correct as it effectively disabled the step: https://github.com/FluentLenium/FluentLenium/runs/2882114284

the new condition tries to improve that by checking two different scenarios:
on a push run the step if its the fluentlenium repo
on a pull_request run the step only if source repo is fluentlenium 