### PR TITLE
fix the custom bePresent FluentWebElement matcher

### DIFF
--- a/fluentlenium-kotest-assertions/src/main/kotlin/org/fluentlenium/kotest/matchers/el/FluentWebElementMatchers.kt
+++ b/fluentlenium-kotest-assertions/src/main/kotlin/org/fluentlenium/kotest/matchers/el/FluentWebElementMatchers.kt
@@ -9,7 +9,7 @@ import org.openqa.selenium.Dimension
 
 fun bePresent() = object : Matcher<FluentWebElement> {
     override fun test(value: FluentWebElement): MatcherResult = MatcherResult(
-        value.enabled(),
+        value.present(),
         "Element '$value' should be present",
         "Element '$value' should not be present"
     )

--- a/fluentlenium-kotest-assertions/src/main/kotlin/org/fluentlenium/kotest/matchers/jq/FluentListMatchers.kt
+++ b/fluentlenium-kotest-assertions/src/main/kotlin/org/fluentlenium/kotest/matchers/jq/FluentListMatchers.kt
@@ -198,3 +198,33 @@ fun haveDimension(expectedDimension: Pair<Int, Int>) =
 fun FluentList<FluentWebElement>.shouldHaveDimension(dimension: Dimension) = also { it should haveDimension(dimension) }
 fun FluentList<FluentWebElement>.shouldNotHaveDimension(dimension: Dimension) =
     also { it shouldNot haveDimension(dimension) }
+
+/**
+ * Checks if any element is present.
+ *
+ * Example:
+ * `jq("button") should bePresent()`
+ *
+ * @return the matcher object.
+ */
+fun bePresent() = object : Matcher<FluentList<FluentWebElement>> {
+    override fun test(value: FluentList<FluentWebElement>): MatcherResult = MatcherResult(
+        value.present(),
+        "Elements '$value' should be present",
+        "Elements '$value' should not be present"
+    )
+}
+
+/**
+ * @see bePresent
+ */
+fun FluentList<FluentWebElement>.shouldBePresent() = also {
+    it should bePresent()
+}
+
+/**
+ * @see bePresent
+ */
+fun FluentList<FluentWebElement>.shouldNotBePresent() = also {
+    it shouldNot bePresent()
+}

--- a/fluentlenium-kotest-assertions/src/test/kotlin/org/fluentlenium/kotest/matchers/el/FluentWebElementWaitHookSpec.kt
+++ b/fluentlenium-kotest-assertions/src/test/kotlin/org/fluentlenium/kotest/matchers/el/FluentWebElementWaitHookSpec.kt
@@ -19,6 +19,6 @@ class FluentWebElementWaitHookSpec : MatcherBase({
     }
 
     "can check for not selected elements when using waithook" {
-        el("#disabled") shouldNot beSelected()
+        el("#not_selected") shouldNot beSelected()
     }
 })

--- a/fluentlenium-kotest-assertions/src/test/kotlin/org/fluentlenium/kotest/matchers/el/FluentWebElementWaitHookSpec.kt
+++ b/fluentlenium-kotest-assertions/src/test/kotlin/org/fluentlenium/kotest/matchers/el/FluentWebElementWaitHookSpec.kt
@@ -9,4 +9,16 @@ class FluentWebElementWaitHookSpec : MatcherBase({
     "can check for absent elements when using waithook" {
         el("#doesNotExist") shouldNot bePresent()
     }
+
+    "can check for not displayed elements when using waithook" {
+        el("#non_display") shouldNot beDisplayed()
+    }
+
+    "can check for not enabled elements when using waithook" {
+        el("#disabled") shouldNot beEnabled()
+    }
+
+    "can check for not selected elements when using waithook" {
+        el("#disabled") shouldNot beSelected()
+    }
 })

--- a/fluentlenium-kotest-assertions/src/test/kotlin/org/fluentlenium/kotest/matchers/el/FluentWebElementWaitHookSpec.kt
+++ b/fluentlenium-kotest-assertions/src/test/kotlin/org/fluentlenium/kotest/matchers/el/FluentWebElementWaitHookSpec.kt
@@ -1,0 +1,12 @@
+package org.fluentlenium.kotest.matchers.el
+
+import io.kotest.matchers.shouldNot
+import org.fluentlenium.core.hook.wait.Wait
+import org.fluentlenium.kotest.matchers.config.MatcherBase
+
+@Wait(timeout = 1)
+class FluentWebElementWaitHookSpec : MatcherBase({
+    "can check for absent elements when using waithook" {
+        el("#doesNotExist") shouldNot bePresent()
+    }
+})

--- a/fluentlenium-kotest-assertions/src/test/kotlin/org/fluentlenium/kotest/matchers/jq/FluentListMatchersSpec.kt
+++ b/fluentlenium-kotest-assertions/src/test/kotlin/org/fluentlenium/kotest/matchers/jq/FluentListMatchersSpec.kt
@@ -15,6 +15,14 @@ class FluentListMatchersSpec : MatcherBase(
             jq("h1").shouldHaveSize(1)
         }
 
+        "present" {
+            jq("#doesNotExist") shouldNot bePresent()
+            jq("#doesNotExist").shouldNotBePresent()
+
+            jq("h1") should bePresent()
+            jq("h1").shouldBePresent()
+        }
+
         "haveText" {
             jq("#choice option") should haveText("First Value")
             jq("#choice option").shouldHaveText("First Value")

--- a/fluentlenium-kotest-assertions/src/test/kotlin/org/fluentlenium/kotest/matchers/jq/FluentListWaitHookSpec.kt
+++ b/fluentlenium-kotest-assertions/src/test/kotlin/org/fluentlenium/kotest/matchers/jq/FluentListWaitHookSpec.kt
@@ -1,0 +1,13 @@
+package org.fluentlenium.kotest.matchers.jq
+
+import io.kotest.matchers.shouldNot
+import org.fluentlenium.adapter.kotest.jq
+import org.fluentlenium.core.hook.wait.Wait
+import org.fluentlenium.kotest.matchers.config.MatcherBase
+
+@Wait(timeout = 1)
+class FluentListWaitHookSpec : MatcherBase({
+    "can check for absent elements when using waithook" {
+        jq("#doesNotExist") shouldNot bePresent()
+    }
+})

--- a/fluentlenium-kotest-assertions/src/test/resources/index.html
+++ b/fluentlenium-kotest-assertions/src/test/resources/index.html
@@ -21,6 +21,7 @@
     <span class="child">Alex</span>
 </span>
 <input id="selected" type="checkbox" value="John" checked/>
+<input id="not_selected" type="checkbox" value="John" />
 <input id="disabled" type="checkbox" value="John" disabled="disabled"/>
 <input id="non_display" type="checkbox" value="John" style="display:none;"/>
 <button id="multiple-css-class" class="class1 class2 class3">Multiple css class</button>

--- a/fluentlenium-kotest/src/test/kotlin/org/fluentlenium/adapter/kotest/describespec/WaitHookPresentSpec.kt
+++ b/fluentlenium-kotest/src/test/kotlin/org/fluentlenium/adapter/kotest/describespec/WaitHookPresentSpec.kt
@@ -1,0 +1,16 @@
+package org.fluentlenium.adapter.kotest.describespec
+
+import io.kotest.matchers.booleans.shouldBeFalse
+import org.fluentlenium.adapter.kotest.FluentDescribeSpec
+import org.fluentlenium.adapter.kotest.TestConstants
+import org.fluentlenium.adapter.kotest.jq
+import org.fluentlenium.core.hook.wait.Wait
+
+@Wait(timeout = 1)
+class WaitHookPresentSpec : FluentDescribeSpec({
+    it("can test for absence when using wait hook") {
+        goTo(TestConstants.DEFAULT_URL)
+        el("#doesNotExist").present().shouldBeFalse()
+        jq("#doesNotExist").present().shouldBeFalse()
+    }
+})


### PR DESCRIPTION
* when used in combination with a WaitHook it was not possible to check for absence of elements
* additionally adds a bePresent FluentList matcher that allows to test for presence/absence