### PR TITLE
Allow to access browser in afterTest callback

### DIFF
--- a/fluentlenium-kotest/src/main/kotlin/org/fluentlenium/adapter/kotest/FluentAnnotationSpec.kt
+++ b/fluentlenium-kotest/src/main/kotlin/org/fluentlenium/adapter/kotest/FluentAnnotationSpec.kt
@@ -48,11 +48,13 @@ abstract class FluentAnnotationSpec internal constructor(
     }
 
     final override fun afterTest(testCase: TestCase, result: TestResult) {
-        doAfterTest(testCase, result)
+        try {
+            doAfterTest(testCase, result)
+        } finally {
+            fluentAdapter.afterTest(testCase, result)
 
-        fluentAdapter.afterTest(testCase, result)
-
-        super.afterTest(testCase, result)
+            super.afterTest(testCase, result)
+        }
     }
 
     open fun doAfterTest(testCase: TestCase, result: TestResult) {}

--- a/fluentlenium-kotest/src/main/kotlin/org/fluentlenium/adapter/kotest/FluentAnnotationSpec.kt
+++ b/fluentlenium-kotest/src/main/kotlin/org/fluentlenium/adapter/kotest/FluentAnnotationSpec.kt
@@ -1,6 +1,8 @@
 package org.fluentlenium.adapter.kotest
 
 import io.kotest.core.spec.style.AnnotationSpec
+import io.kotest.core.test.TestCase
+import io.kotest.core.test.TestResult
 import org.fluentlenium.adapter.IFluentAdapter
 import org.fluentlenium.adapter.TestRunnerAdapter
 import org.fluentlenium.adapter.exception.AnnotationNotFoundException
@@ -20,7 +22,7 @@ abstract class FluentAnnotationSpec internal constructor(
     init {
         fluentAdapter.useConfigurationOverride = { configuration }
 
-        listener(fluentAdapter.listener())
+        listener(fluentAdapter.listener)
     }
 
     private val config: Configuration by lazy {
@@ -44,4 +46,14 @@ abstract class FluentAnnotationSpec internal constructor(
 
         return currentTestMethod.getAnnotation(annotation) ?: throw AnnotationNotFoundException()
     }
+
+    override fun afterTest(testCase: TestCase, result: TestResult) {
+        doAfterTest(testCase, result)
+
+        fluentAdapter.afterTest(testCase, result)
+
+        super.afterTest(testCase, result)
+    }
+
+    open fun doAfterTest(testCase: TestCase, result: TestResult) {}
 }

--- a/fluentlenium-kotest/src/main/kotlin/org/fluentlenium/adapter/kotest/FluentAnnotationSpec.kt
+++ b/fluentlenium-kotest/src/main/kotlin/org/fluentlenium/adapter/kotest/FluentAnnotationSpec.kt
@@ -47,7 +47,7 @@ abstract class FluentAnnotationSpec internal constructor(
         return currentTestMethod.getAnnotation(annotation) ?: throw AnnotationNotFoundException()
     }
 
-    override fun afterTest(testCase: TestCase, result: TestResult) {
+    final override fun afterTest(testCase: TestCase, result: TestResult) {
         doAfterTest(testCase, result)
 
         fluentAdapter.afterTest(testCase, result)

--- a/fluentlenium-kotest/src/main/kotlin/org/fluentlenium/adapter/kotest/FluentBehaviorSpec.kt
+++ b/fluentlenium-kotest/src/main/kotlin/org/fluentlenium/adapter/kotest/FluentBehaviorSpec.kt
@@ -53,11 +53,13 @@ abstract class FluentBehaviorSpec internal constructor(
     }
 
     final override fun afterTest(testCase: TestCase, result: TestResult) {
-        doAfterTest(testCase, result)
+        try {
+            doAfterTest(testCase, result)
+        } finally {
+            fluentAdapter.afterTest(testCase, result)
 
-        fluentAdapter.afterTest(testCase, result)
-
-        super.afterTest(testCase, result)
+            super.afterTest(testCase, result)
+        }
     }
 
     open fun doAfterTest(testCase: TestCase, result: TestResult) {}

--- a/fluentlenium-kotest/src/main/kotlin/org/fluentlenium/adapter/kotest/FluentBehaviorSpec.kt
+++ b/fluentlenium-kotest/src/main/kotlin/org/fluentlenium/adapter/kotest/FluentBehaviorSpec.kt
@@ -52,7 +52,7 @@ abstract class FluentBehaviorSpec internal constructor(
         return super.getFluentControl()
     }
 
-    override fun afterTest(testCase: TestCase, result: TestResult) {
+    final override fun afterTest(testCase: TestCase, result: TestResult) {
         doAfterTest(testCase, result)
 
         fluentAdapter.afterTest(testCase, result)

--- a/fluentlenium-kotest/src/main/kotlin/org/fluentlenium/adapter/kotest/FluentBehaviorSpec.kt
+++ b/fluentlenium-kotest/src/main/kotlin/org/fluentlenium/adapter/kotest/FluentBehaviorSpec.kt
@@ -1,6 +1,8 @@
 package org.fluentlenium.adapter.kotest
 
 import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.core.test.TestCase
+import io.kotest.core.test.TestResult
 import org.fluentlenium.adapter.IFluentAdapter
 import org.fluentlenium.adapter.TestRunnerAdapter
 import org.fluentlenium.adapter.exception.AnnotationNotFoundException
@@ -21,7 +23,7 @@ abstract class FluentBehaviorSpec internal constructor(
     init {
         fluentAdapter.useConfigurationOverride = { configuration }
 
-        listener(fluentAdapter.listener())
+        listener(fluentAdapter.listener)
 
         body()
     }
@@ -49,4 +51,14 @@ abstract class FluentBehaviorSpec internal constructor(
 
         return super.getFluentControl()
     }
+
+    override fun afterTest(testCase: TestCase, result: TestResult) {
+        doAfterTest(testCase, result)
+
+        fluentAdapter.afterTest(testCase, result)
+
+        super.afterTest(testCase, result)
+    }
+
+    open fun doAfterTest(testCase: TestCase, result: TestResult) {}
 }

--- a/fluentlenium-kotest/src/main/kotlin/org/fluentlenium/adapter/kotest/FluentBehaviorSpec.kt
+++ b/fluentlenium-kotest/src/main/kotlin/org/fluentlenium/adapter/kotest/FluentBehaviorSpec.kt
@@ -13,7 +13,7 @@ import org.fluentlenium.core.inject.ContainerFluentControl
 
 abstract class FluentBehaviorSpec internal constructor(
     private val fluentAdapter: KoTestFluentAdapter,
-    body: FluentBehaviorSpec.() -> Unit = {}
+    body: FluentBehaviorSpec.() -> Unit
 ) : BehaviorSpec({}),
     IFluentAdapter by fluentAdapter,
     TestRunnerAdapter {

--- a/fluentlenium-kotest/src/main/kotlin/org/fluentlenium/adapter/kotest/FluentDescribeSpec.kt
+++ b/fluentlenium-kotest/src/main/kotlin/org/fluentlenium/adapter/kotest/FluentDescribeSpec.kt
@@ -1,6 +1,8 @@
 package org.fluentlenium.adapter.kotest
 
 import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.core.test.TestCase
+import io.kotest.core.test.TestResult
 import org.fluentlenium.adapter.IFluentAdapter
 import org.fluentlenium.adapter.TestRunnerAdapter
 import org.fluentlenium.adapter.exception.AnnotationNotFoundException
@@ -20,7 +22,7 @@ abstract class FluentDescribeSpec internal constructor(
     init {
         fluentAdapter.useConfigurationOverride = { configuration }
 
-        listener(fluentAdapter.listener())
+        listener(fluentAdapter.listener)
 
         body()
     }
@@ -42,4 +44,14 @@ abstract class FluentDescribeSpec internal constructor(
     override fun <T : Annotation?> getMethodAnnotation(annotation: Class<T>?): T {
         throw AnnotationNotFoundException()
     }
+
+    final override fun afterTest(testCase: TestCase, result: TestResult) {
+        doAfterTest(testCase, result)
+
+        fluentAdapter.afterTest(testCase, result)
+
+        super.afterTest(testCase, result)
+    }
+
+    open fun doAfterTest(testCase: TestCase, result: TestResult) {}
 }

--- a/fluentlenium-kotest/src/main/kotlin/org/fluentlenium/adapter/kotest/FluentDescribeSpec.kt
+++ b/fluentlenium-kotest/src/main/kotlin/org/fluentlenium/adapter/kotest/FluentDescribeSpec.kt
@@ -12,7 +12,7 @@ import org.fluentlenium.configuration.ConfigurationFactoryProvider
 
 abstract class FluentDescribeSpec internal constructor(
     private val fluentAdapter: KoTestFluentAdapter,
-    body: FluentDescribeSpec.() -> Unit = {}
+    body: FluentDescribeSpec.() -> Unit
 ) : DescribeSpec({ }),
     IFluentAdapter by fluentAdapter,
     TestRunnerAdapter {

--- a/fluentlenium-kotest/src/main/kotlin/org/fluentlenium/adapter/kotest/FluentDescribeSpec.kt
+++ b/fluentlenium-kotest/src/main/kotlin/org/fluentlenium/adapter/kotest/FluentDescribeSpec.kt
@@ -46,11 +46,13 @@ abstract class FluentDescribeSpec internal constructor(
     }
 
     final override fun afterTest(testCase: TestCase, result: TestResult) {
-        doAfterTest(testCase, result)
+        try {
+            doAfterTest(testCase, result)
+        } finally {
+            fluentAdapter.afterTest(testCase, result)
 
-        fluentAdapter.afterTest(testCase, result)
-
-        super.afterTest(testCase, result)
+            super.afterTest(testCase, result)
+        }
     }
 
     open fun doAfterTest(testCase: TestCase, result: TestResult) {}

--- a/fluentlenium-kotest/src/main/kotlin/org/fluentlenium/adapter/kotest/FluentExpectSpec.kt
+++ b/fluentlenium-kotest/src/main/kotlin/org/fluentlenium/adapter/kotest/FluentExpectSpec.kt
@@ -1,6 +1,8 @@
 package org.fluentlenium.adapter.kotest
 
 import io.kotest.core.spec.style.ExpectSpec
+import io.kotest.core.test.TestCase
+import io.kotest.core.test.TestResult
 import org.fluentlenium.adapter.IFluentAdapter
 import org.fluentlenium.adapter.TestRunnerAdapter
 import org.fluentlenium.adapter.exception.AnnotationNotFoundException
@@ -21,7 +23,7 @@ abstract class FluentExpectSpec internal constructor(
     init {
         fluentAdapter.useConfigurationOverride = { configuration }
 
-        listener(fluentAdapter.listener())
+        listener(fluentAdapter.listener)
 
         body()
     }
@@ -49,4 +51,14 @@ abstract class FluentExpectSpec internal constructor(
 
         return super.getFluentControl()
     }
+
+    final override fun afterTest(testCase: TestCase, result: TestResult) {
+        doAfterTest(testCase, result)
+
+        fluentAdapter.afterTest(testCase, result)
+
+        super.afterTest(testCase, result)
+    }
+
+    open fun doAfterTest(testCase: TestCase, result: TestResult) {}
 }

--- a/fluentlenium-kotest/src/main/kotlin/org/fluentlenium/adapter/kotest/FluentExpectSpec.kt
+++ b/fluentlenium-kotest/src/main/kotlin/org/fluentlenium/adapter/kotest/FluentExpectSpec.kt
@@ -13,7 +13,7 @@ import org.fluentlenium.core.inject.ContainerFluentControl
 
 abstract class FluentExpectSpec internal constructor(
     private val fluentAdapter: KoTestFluentAdapter,
-    body: FluentExpectSpec.() -> Unit = {}
+    body: FluentExpectSpec.() -> Unit
 ) : ExpectSpec({}),
     IFluentAdapter by fluentAdapter,
     TestRunnerAdapter {

--- a/fluentlenium-kotest/src/main/kotlin/org/fluentlenium/adapter/kotest/FluentExpectSpec.kt
+++ b/fluentlenium-kotest/src/main/kotlin/org/fluentlenium/adapter/kotest/FluentExpectSpec.kt
@@ -53,11 +53,13 @@ abstract class FluentExpectSpec internal constructor(
     }
 
     final override fun afterTest(testCase: TestCase, result: TestResult) {
-        doAfterTest(testCase, result)
+        try {
+            doAfterTest(testCase, result)
+        } finally {
+            fluentAdapter.afterTest(testCase, result)
 
-        fluentAdapter.afterTest(testCase, result)
-
-        super.afterTest(testCase, result)
+            super.afterTest(testCase, result)
+        }
     }
 
     open fun doAfterTest(testCase: TestCase, result: TestResult) {}

--- a/fluentlenium-kotest/src/main/kotlin/org/fluentlenium/adapter/kotest/FluentFeatureSpec.kt
+++ b/fluentlenium-kotest/src/main/kotlin/org/fluentlenium/adapter/kotest/FluentFeatureSpec.kt
@@ -53,11 +53,13 @@ abstract class FluentFeatureSpec internal constructor(
     }
 
     final override fun afterTest(testCase: TestCase, result: TestResult) {
-        doAfterTest(testCase, result)
+        try {
+            doAfterTest(testCase, result)
+        } finally {
+            fluentAdapter.afterTest(testCase, result)
 
-        fluentAdapter.afterTest(testCase, result)
-
-        super.afterTest(testCase, result)
+            super.afterTest(testCase, result)
+        }
     }
 
     open fun doAfterTest(testCase: TestCase, result: TestResult) {}

--- a/fluentlenium-kotest/src/main/kotlin/org/fluentlenium/adapter/kotest/FluentFeatureSpec.kt
+++ b/fluentlenium-kotest/src/main/kotlin/org/fluentlenium/adapter/kotest/FluentFeatureSpec.kt
@@ -1,6 +1,8 @@
 package org.fluentlenium.adapter.kotest
 
 import io.kotest.core.spec.style.FeatureSpec
+import io.kotest.core.test.TestCase
+import io.kotest.core.test.TestResult
 import org.fluentlenium.adapter.IFluentAdapter
 import org.fluentlenium.adapter.TestRunnerAdapter
 import org.fluentlenium.adapter.exception.AnnotationNotFoundException
@@ -21,7 +23,7 @@ abstract class FluentFeatureSpec internal constructor(
     init {
         fluentAdapter.useConfigurationOverride = { configuration }
 
-        listener(fluentAdapter.listener())
+        listener(fluentAdapter.listener)
 
         body()
     }
@@ -49,4 +51,14 @@ abstract class FluentFeatureSpec internal constructor(
 
         return super.getFluentControl()
     }
+
+    final override fun afterTest(testCase: TestCase, result: TestResult) {
+        doAfterTest(testCase, result)
+
+        fluentAdapter.afterTest(testCase, result)
+
+        super.afterTest(testCase, result)
+    }
+
+    open fun doAfterTest(testCase: TestCase, result: TestResult) {}
 }

--- a/fluentlenium-kotest/src/main/kotlin/org/fluentlenium/adapter/kotest/FluentFeatureSpec.kt
+++ b/fluentlenium-kotest/src/main/kotlin/org/fluentlenium/adapter/kotest/FluentFeatureSpec.kt
@@ -13,7 +13,7 @@ import org.fluentlenium.core.inject.ContainerFluentControl
 
 abstract class FluentFeatureSpec internal constructor(
     private val fluentAdapter: KoTestFluentAdapter,
-    body: FluentFeatureSpec.() -> Unit = {}
+    body: FluentFeatureSpec.() -> Unit
 ) : FeatureSpec({}),
     IFluentAdapter by fluentAdapter,
     TestRunnerAdapter {

--- a/fluentlenium-kotest/src/main/kotlin/org/fluentlenium/adapter/kotest/FluentFreeSpec.kt
+++ b/fluentlenium-kotest/src/main/kotlin/org/fluentlenium/adapter/kotest/FluentFreeSpec.kt
@@ -13,7 +13,7 @@ import org.fluentlenium.core.inject.ContainerFluentControl
 
 abstract class FluentFreeSpec internal constructor(
     private val fluentAdapter: KoTestFluentAdapter,
-    body: FluentFreeSpec.() -> Unit = {}
+    body: FluentFreeSpec.() -> Unit
 ) : FreeSpec({}),
     IFluentAdapter by fluentAdapter,
     TestRunnerAdapter {

--- a/fluentlenium-kotest/src/main/kotlin/org/fluentlenium/adapter/kotest/FluentFreeSpec.kt
+++ b/fluentlenium-kotest/src/main/kotlin/org/fluentlenium/adapter/kotest/FluentFreeSpec.kt
@@ -53,11 +53,13 @@ abstract class FluentFreeSpec internal constructor(
     }
 
     final override fun afterTest(testCase: TestCase, result: TestResult) {
-        doAfterTest(testCase, result)
+        try {
+            doAfterTest(testCase, result)
+        } finally {
+            fluentAdapter.afterTest(testCase, result)
 
-        fluentAdapter.afterTest(testCase, result)
-
-        super.afterTest(testCase, result)
+            super.afterTest(testCase, result)
+        }
     }
 
     open fun doAfterTest(testCase: TestCase, result: TestResult) {}

--- a/fluentlenium-kotest/src/main/kotlin/org/fluentlenium/adapter/kotest/FluentFreeSpec.kt
+++ b/fluentlenium-kotest/src/main/kotlin/org/fluentlenium/adapter/kotest/FluentFreeSpec.kt
@@ -1,6 +1,8 @@
 package org.fluentlenium.adapter.kotest
 
 import io.kotest.core.spec.style.FreeSpec
+import io.kotest.core.test.TestCase
+import io.kotest.core.test.TestResult
 import org.fluentlenium.adapter.IFluentAdapter
 import org.fluentlenium.adapter.TestRunnerAdapter
 import org.fluentlenium.adapter.exception.AnnotationNotFoundException
@@ -21,7 +23,7 @@ abstract class FluentFreeSpec internal constructor(
     init {
         fluentAdapter.useConfigurationOverride = { configuration }
 
-        listener(fluentAdapter.listener())
+        listener(fluentAdapter.listener)
 
         body()
     }
@@ -49,4 +51,14 @@ abstract class FluentFreeSpec internal constructor(
 
         return super.getFluentControl()
     }
+
+    final override fun afterTest(testCase: TestCase, result: TestResult) {
+        doAfterTest(testCase, result)
+
+        fluentAdapter.afterTest(testCase, result)
+
+        super.afterTest(testCase, result)
+    }
+
+    open fun doAfterTest(testCase: TestCase, result: TestResult) {}
 }

--- a/fluentlenium-kotest/src/main/kotlin/org/fluentlenium/adapter/kotest/FluentFunSpec.kt
+++ b/fluentlenium-kotest/src/main/kotlin/org/fluentlenium/adapter/kotest/FluentFunSpec.kt
@@ -46,11 +46,13 @@ abstract class FluentFunSpec internal constructor(
     }
 
     final override fun afterTest(testCase: TestCase, result: TestResult) {
-        doAfterTest(testCase, result)
+        try {
+            doAfterTest(testCase, result)
+        } finally {
+            fluentAdapter.afterTest(testCase, result)
 
-        fluentAdapter.afterTest(testCase, result)
-
-        super.afterTest(testCase, result)
+            super.afterTest(testCase, result)
+        }
     }
 
     open fun doAfterTest(testCase: TestCase, result: TestResult) {}

--- a/fluentlenium-kotest/src/main/kotlin/org/fluentlenium/adapter/kotest/FluentFunSpec.kt
+++ b/fluentlenium-kotest/src/main/kotlin/org/fluentlenium/adapter/kotest/FluentFunSpec.kt
@@ -12,7 +12,7 @@ import org.fluentlenium.configuration.ConfigurationFactoryProvider
 
 abstract class FluentFunSpec internal constructor(
     private val fluentAdapter: KoTestFluentAdapter,
-    body: FluentFunSpec.() -> Unit = {}
+    body: FluentFunSpec.() -> Unit
 ) : FunSpec({ }),
     IFluentAdapter by fluentAdapter,
     TestRunnerAdapter {

--- a/fluentlenium-kotest/src/main/kotlin/org/fluentlenium/adapter/kotest/FluentFunSpec.kt
+++ b/fluentlenium-kotest/src/main/kotlin/org/fluentlenium/adapter/kotest/FluentFunSpec.kt
@@ -1,6 +1,8 @@
 package org.fluentlenium.adapter.kotest
 
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.test.TestCase
+import io.kotest.core.test.TestResult
 import org.fluentlenium.adapter.IFluentAdapter
 import org.fluentlenium.adapter.TestRunnerAdapter
 import org.fluentlenium.adapter.exception.AnnotationNotFoundException
@@ -20,7 +22,7 @@ abstract class FluentFunSpec internal constructor(
     init {
         fluentAdapter.useConfigurationOverride = { configuration }
 
-        listener(fluentAdapter.listener())
+        listener(fluentAdapter.listener)
 
         body()
     }
@@ -42,4 +44,14 @@ abstract class FluentFunSpec internal constructor(
     override fun <T : Annotation?> getMethodAnnotation(annotation: Class<T>?): T {
         throw AnnotationNotFoundException()
     }
+
+    final override fun afterTest(testCase: TestCase, result: TestResult) {
+        doAfterTest(testCase, result)
+
+        fluentAdapter.afterTest(testCase, result)
+
+        super.afterTest(testCase, result)
+    }
+
+    open fun doAfterTest(testCase: TestCase, result: TestResult) {}
 }

--- a/fluentlenium-kotest/src/main/kotlin/org/fluentlenium/adapter/kotest/FluentShouldSpec.kt
+++ b/fluentlenium-kotest/src/main/kotlin/org/fluentlenium/adapter/kotest/FluentShouldSpec.kt
@@ -13,7 +13,7 @@ import org.fluentlenium.core.inject.ContainerFluentControl
 
 abstract class FluentShouldSpec internal constructor(
     private val fluentAdapter: KoTestFluentAdapter,
-    body: FluentShouldSpec.() -> Unit = {}
+    body: FluentShouldSpec.() -> Unit
 ) : ShouldSpec({}),
     IFluentAdapter by fluentAdapter,
     TestRunnerAdapter {

--- a/fluentlenium-kotest/src/main/kotlin/org/fluentlenium/adapter/kotest/FluentShouldSpec.kt
+++ b/fluentlenium-kotest/src/main/kotlin/org/fluentlenium/adapter/kotest/FluentShouldSpec.kt
@@ -53,11 +53,13 @@ abstract class FluentShouldSpec internal constructor(
     }
 
     final override fun afterTest(testCase: TestCase, result: TestResult) {
-        doAfterTest(testCase, result)
+        try {
+            doAfterTest(testCase, result)
+        } finally {
+            fluentAdapter.afterTest(testCase, result)
 
-        fluentAdapter.afterTest(testCase, result)
-
-        super.afterTest(testCase, result)
+            super.afterTest(testCase, result)
+        }
     }
 
     open fun doAfterTest(testCase: TestCase, result: TestResult) {}

--- a/fluentlenium-kotest/src/main/kotlin/org/fluentlenium/adapter/kotest/FluentShouldSpec.kt
+++ b/fluentlenium-kotest/src/main/kotlin/org/fluentlenium/adapter/kotest/FluentShouldSpec.kt
@@ -1,6 +1,8 @@
 package org.fluentlenium.adapter.kotest
 
 import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.core.test.TestCase
+import io.kotest.core.test.TestResult
 import org.fluentlenium.adapter.IFluentAdapter
 import org.fluentlenium.adapter.TestRunnerAdapter
 import org.fluentlenium.adapter.exception.AnnotationNotFoundException
@@ -21,7 +23,7 @@ abstract class FluentShouldSpec internal constructor(
     init {
         fluentAdapter.useConfigurationOverride = { configuration }
 
-        listener(fluentAdapter.listener())
+        listener(fluentAdapter.listener)
 
         body()
     }
@@ -49,4 +51,14 @@ abstract class FluentShouldSpec internal constructor(
 
         return super.getFluentControl()
     }
+
+    final override fun afterTest(testCase: TestCase, result: TestResult) {
+        doAfterTest(testCase, result)
+
+        fluentAdapter.afterTest(testCase, result)
+
+        super.afterTest(testCase, result)
+    }
+
+    open fun doAfterTest(testCase: TestCase, result: TestResult) {}
 }

--- a/fluentlenium-kotest/src/main/kotlin/org/fluentlenium/adapter/kotest/FluentStringSpec.kt
+++ b/fluentlenium-kotest/src/main/kotlin/org/fluentlenium/adapter/kotest/FluentStringSpec.kt
@@ -1,6 +1,8 @@
 package org.fluentlenium.adapter.kotest
 
 import io.kotest.core.spec.style.StringSpec
+import io.kotest.core.test.TestCase
+import io.kotest.core.test.TestResult
 import org.fluentlenium.adapter.IFluentAdapter
 import org.fluentlenium.adapter.TestRunnerAdapter
 import org.fluentlenium.adapter.exception.AnnotationNotFoundException
@@ -20,7 +22,7 @@ abstract class FluentStringSpec internal constructor(
     init {
         fluentAdapter.useConfigurationOverride = { configuration }
 
-        listener(fluentAdapter.listener())
+        listener(fluentAdapter.listener)
 
         body()
     }
@@ -42,4 +44,14 @@ abstract class FluentStringSpec internal constructor(
     override fun <T : Annotation?> getMethodAnnotation(annotation: Class<T>?): T {
         throw AnnotationNotFoundException()
     }
+
+    final override fun afterTest(testCase: TestCase, result: TestResult) {
+        doAfterTest(testCase, result)
+
+        fluentAdapter.afterTest(testCase, result)
+
+        super.afterTest(testCase, result)
+    }
+
+    open fun doAfterTest(testCase: TestCase, result: TestResult) {}
 }

--- a/fluentlenium-kotest/src/main/kotlin/org/fluentlenium/adapter/kotest/FluentStringSpec.kt
+++ b/fluentlenium-kotest/src/main/kotlin/org/fluentlenium/adapter/kotest/FluentStringSpec.kt
@@ -46,11 +46,13 @@ abstract class FluentStringSpec internal constructor(
     }
 
     final override fun afterTest(testCase: TestCase, result: TestResult) {
-        doAfterTest(testCase, result)
+        try {
+            doAfterTest(testCase, result)
+        } finally {
+            fluentAdapter.afterTest(testCase, result)
 
-        fluentAdapter.afterTest(testCase, result)
-
-        super.afterTest(testCase, result)
+            super.afterTest(testCase, result)
+        }
     }
 
     open fun doAfterTest(testCase: TestCase, result: TestResult) {}

--- a/fluentlenium-kotest/src/main/kotlin/org/fluentlenium/adapter/kotest/FluentStringSpec.kt
+++ b/fluentlenium-kotest/src/main/kotlin/org/fluentlenium/adapter/kotest/FluentStringSpec.kt
@@ -12,7 +12,7 @@ import org.fluentlenium.configuration.ConfigurationFactoryProvider
 
 abstract class FluentStringSpec internal constructor(
     private val fluentAdapter: KoTestFluentAdapter,
-    body: FluentStringSpec.() -> Unit = {}
+    body: FluentStringSpec.() -> Unit
 ) : StringSpec({}),
     IFluentAdapter by fluentAdapter,
     TestRunnerAdapter {

--- a/fluentlenium-kotest/src/main/kotlin/org/fluentlenium/adapter/kotest/FluentWordSpec.kt
+++ b/fluentlenium-kotest/src/main/kotlin/org/fluentlenium/adapter/kotest/FluentWordSpec.kt
@@ -53,11 +53,13 @@ abstract class FluentWordSpec internal constructor(
     }
 
     final override fun afterTest(testCase: TestCase, result: TestResult) {
-        doAfterTest(testCase, result)
+        try {
+            doAfterTest(testCase, result)
+        } finally {
+            fluentAdapter.afterTest(testCase, result)
 
-        fluentAdapter.afterTest(testCase, result)
-
-        super.afterTest(testCase, result)
+            super.afterTest(testCase, result)
+        }
     }
 
     open fun doAfterTest(testCase: TestCase, result: TestResult) {}

--- a/fluentlenium-kotest/src/main/kotlin/org/fluentlenium/adapter/kotest/FluentWordSpec.kt
+++ b/fluentlenium-kotest/src/main/kotlin/org/fluentlenium/adapter/kotest/FluentWordSpec.kt
@@ -1,6 +1,8 @@
 package org.fluentlenium.adapter.kotest
 
 import io.kotest.core.spec.style.WordSpec
+import io.kotest.core.test.TestCase
+import io.kotest.core.test.TestResult
 import org.fluentlenium.adapter.IFluentAdapter
 import org.fluentlenium.adapter.TestRunnerAdapter
 import org.fluentlenium.adapter.exception.AnnotationNotFoundException
@@ -21,7 +23,7 @@ abstract class FluentWordSpec internal constructor(
     init {
         fluentAdapter.useConfigurationOverride = { configuration }
 
-        listener(fluentAdapter.listener())
+        listener(fluentAdapter.listener)
 
         body()
     }
@@ -49,4 +51,14 @@ abstract class FluentWordSpec internal constructor(
 
         return super.getFluentControl()
     }
+
+    final override fun afterTest(testCase: TestCase, result: TestResult) {
+        doAfterTest(testCase, result)
+
+        fluentAdapter.afterTest(testCase, result)
+
+        super.afterTest(testCase, result)
+    }
+
+    open fun doAfterTest(testCase: TestCase, result: TestResult) {}
 }

--- a/fluentlenium-kotest/src/main/kotlin/org/fluentlenium/adapter/kotest/FluentWordSpec.kt
+++ b/fluentlenium-kotest/src/main/kotlin/org/fluentlenium/adapter/kotest/FluentWordSpec.kt
@@ -13,7 +13,7 @@ import org.fluentlenium.core.inject.ContainerFluentControl
 
 abstract class FluentWordSpec internal constructor(
     private val fluentAdapter: KoTestFluentAdapter,
-    body: FluentWordSpec.() -> Unit = {}
+    body: FluentWordSpec.() -> Unit
 ) : WordSpec({}),
     IFluentAdapter by fluentAdapter,
     TestRunnerAdapter {

--- a/fluentlenium-kotest/src/main/kotlin/org/fluentlenium/adapter/kotest/internal/KoTestFluentAdapter.kt
+++ b/fluentlenium-kotest/src/main/kotlin/org/fluentlenium/adapter/kotest/internal/KoTestFluentAdapter.kt
@@ -130,8 +130,8 @@ internal class KoTestFluentAdapter constructor(var useConfigurationOverride: () 
     }
 
     fun ensureTestStarted() {
-        if (currentTestName.get() == null) {
-            throw IllegalStateException("FluentLenium is not yet available! Make sure to use FluentLenium only within the innermost Kotest test block!")
+        checkNotNull(currentTestName.get()) {
+            "FluentLenium is not yet available! Make sure to use FluentLenium only within the innermost Kotest test block!"
         }
     }
 }

--- a/fluentlenium-kotest/src/main/kotlin/org/fluentlenium/adapter/kotest/internal/KoTestFluentAdapter.kt
+++ b/fluentlenium-kotest/src/main/kotlin/org/fluentlenium/adapter/kotest/internal/KoTestFluentAdapter.kt
@@ -74,7 +74,6 @@ internal class KoTestFluentAdapter constructor(var useConfigurationOverride: () 
             "fluentlenium-kotest is incompatible with dispatcherAffinity=false. set to true!"
         }
 
-        val thisListener = this
         val testClass = testCase.spec.javaClass
         val testName = testCase.displayName
 

--- a/fluentlenium-kotest/src/test/kotlin/org/fluentlenium/adapter/kotest/describespec/CanAccessDriverInAfterTestSpec.kt
+++ b/fluentlenium-kotest/src/test/kotlin/org/fluentlenium/adapter/kotest/describespec/CanAccessDriverInAfterTestSpec.kt
@@ -1,0 +1,24 @@
+package org.fluentlenium.adapter.kotest.describespec
+
+import io.kotest.core.test.TestCase
+import io.kotest.core.test.TestResult
+import io.kotest.matchers.string.shouldContain
+import org.fluentlenium.adapter.kotest.FluentDescribeSpec
+import org.fluentlenium.adapter.kotest.TestConstants.DEFAULT_URL
+
+class CanAccessDriverInAfterTestSpec : FluentDescribeSpec() {
+    init {
+        it("can user browser in afterTest") {
+            goTo(DEFAULT_URL)
+            window().title() shouldContain "Fluent"
+        }
+
+        afterTest {
+            goTo(DEFAULT_URL)
+        }
+    }
+
+    override fun doAfterTest(testCase: TestCase, result: TestResult) {
+        goTo(DEFAULT_URL)
+    }
+}


### PR DESCRIPTION
The order in wich Kotest _afterTest_ callbacks are run is not defined. In consequence it was not possible to access the browser in Kotest _afterTest_ callbacks. The browser was already closed at that time.

This PR closes the browser as late as possible by overriding the _afterTest_ function. This will ensure that the browser will still be open in other afterTest callbacks.