### PR TITLE
less verbose ChromeDriver logging

### DIFF
--- a/fluentlenium-assertj/pom.xml
+++ b/fluentlenium-assertj/pom.xml
@@ -83,6 +83,11 @@
             <artifactId>selenium-devtools-v95</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jul-to-slf4j</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -92,6 +97,8 @@
                 <configuration>
                     <systemPropertyVariables>
                         <fluentlenium.capabilities>{"chromeOptions": {"args": ["headless","no-sandbox", "disable-gpu", "disable-dev-shm-usage"]}}</fluentlenium.capabilities>
+                        <java.util.logging.config.file>${project.basedir}/src/test/resources/logging.properties</java.util.logging.config.file>
+                        <webdriver.chrome.silentOutput>true</webdriver.chrome.silentOutput>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>

--- a/fluentlenium-assertj/src/test/resources/logging.properties
+++ b/fluentlenium-assertj/src/test/resources/logging.properties
@@ -1,0 +1,1 @@
+handlers=org.slf4j.bridge.SLF4JBridgeHandler

--- a/fluentlenium-core/pom.xml
+++ b/fluentlenium-core/pom.xml
@@ -165,6 +165,11 @@
             <artifactId>logback-classic</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jul-to-slf4j</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/fluentlenium-cucumber/pom.xml
+++ b/fluentlenium-cucumber/pom.xml
@@ -84,6 +84,11 @@
             <artifactId>selenium-devtools-v95</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jul-to-slf4j</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -93,6 +98,8 @@
                 <configuration>
                     <systemPropertyVariables>
                         <fluentlenium.capabilities>{"chromeOptions": {"args": ["headless","no-sandbox", "disable-gpu", "disable-dev-shm-usage"]}}</fluentlenium.capabilities>
+                        <java.util.logging.config.file>${project.basedir}/src/test/resources/logging.properties</java.util.logging.config.file>
+                        <webdriver.chrome.silentOutput>true</webdriver.chrome.silentOutput>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>
@@ -104,6 +111,8 @@
                     </includes>
                     <systemPropertyVariables>
                         <fluentlenium.capabilities>{"chromeOptions": {"args": ["headless","no-sandbox", "disable-gpu", "disable-dev-shm-usage"]}}</fluentlenium.capabilities>
+                        <java.util.logging.config.file>${project.basedir}/src/test/resources/logging.properties</java.util.logging.config.file>
+                        <webdriver.chrome.silentOutput>true</webdriver.chrome.silentOutput>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>

--- a/fluentlenium-integration-tests/pom.xml
+++ b/fluentlenium-integration-tests/pom.xml
@@ -79,6 +79,11 @@
             <artifactId>selenium-devtools-v95</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jul-to-slf4j</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -88,6 +93,8 @@
                 <configuration>
                     <systemPropertyVariables>
                         <fluentlenium.capabilities>{"chromeOptions": {"args": ["headless","no-sandbox", "disable-gpu", "disable-dev-shm-usage"]}}</fluentlenium.capabilities>
+                        <java.util.logging.config.file>${project.basedir}/src/test/resources/logging.properties</java.util.logging.config.file>
+                        <webdriver.chrome.silentOutput>true</webdriver.chrome.silentOutput>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>

--- a/fluentlenium-junit-jupiter/pom.xml
+++ b/fluentlenium-junit-jupiter/pom.xml
@@ -79,6 +79,11 @@
             <artifactId>logback-classic</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jul-to-slf4j</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -88,6 +93,8 @@
                 <configuration>
                     <systemPropertyVariables>
                         <fluentlenium.capabilities>{"chromeOptions": {"args": ["headless","no-sandbox", "disable-gpu", "disable-dev-shm-usage"]}}</fluentlenium.capabilities>
+                        <java.util.logging.config.file>${project.basedir}/src/test/resources/logging.properties</java.util.logging.config.file>
+                        <webdriver.chrome.silentOutput>true</webdriver.chrome.silentOutput>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>
@@ -96,6 +103,8 @@
                 <configuration>
                     <systemPropertyVariables>
                         <fluentlenium.capabilities>{"chromeOptions": {"args": ["headless","no-sandbox", "disable-gpu", "disable-dev-shm-usage"]}}</fluentlenium.capabilities>
+                        <java.util.logging.config.file>${project.basedir}/src/test/resources/logging.properties</java.util.logging.config.file>
+                        <webdriver.chrome.silentOutput>true</webdriver.chrome.silentOutput>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>

--- a/fluentlenium-junit-jupiter/src/test/resources/logging.properties
+++ b/fluentlenium-junit-jupiter/src/test/resources/logging.properties
@@ -1,0 +1,1 @@
+handlers=org.slf4j.bridge.SLF4JBridgeHandler

--- a/fluentlenium-junit/pom.xml
+++ b/fluentlenium-junit/pom.xml
@@ -72,6 +72,11 @@
             <artifactId>logback-classic</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jul-to-slf4j</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -81,6 +86,8 @@
                 <configuration>
                     <systemPropertyVariables>
                         <fluentlenium.capabilities>{"chromeOptions": {"args": ["headless","no-sandbox", "disable-gpu", "disable-dev-shm-usage"]}}</fluentlenium.capabilities>
+                        <java.util.logging.config.file>${project.basedir}/src/test/resources/logging.properties</java.util.logging.config.file>
+                        <webdriver.chrome.silentOutput>true</webdriver.chrome.silentOutput>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>
@@ -89,6 +96,8 @@
                 <configuration>
                     <systemPropertyVariables>
                         <fluentlenium.capabilities>{"chromeOptions": {"args": ["headless","no-sandbox", "disable-gpu", "disable-dev-shm-usage"]}}</fluentlenium.capabilities>
+                        <java.util.logging.config.file>${project.basedir}/src/test/resources/logging.properties</java.util.logging.config.file>
+                        <webdriver.chrome.silentOutput>true</webdriver.chrome.silentOutput>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>

--- a/fluentlenium-kotest-assertions/pom.xml
+++ b/fluentlenium-kotest-assertions/pom.xml
@@ -89,6 +89,11 @@
             <version>${selenium.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jul-to-slf4j</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -133,6 +138,8 @@
 
                     <systemPropertyVariables>
                         <fluentlenium.capabilities>{"chromeOptions": {"args": ["headless","no-sandbox", "disable-gpu", "disable-dev-shm-usage"]}}</fluentlenium.capabilities>
+                        <java.util.logging.config.file>${project.basedir}/src/test/resources/logging.properties</java.util.logging.config.file>
+                        <webdriver.chrome.silentOutput>true</webdriver.chrome.silentOutput>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>

--- a/fluentlenium-kotest-assertions/src/test/resources/logging.properties
+++ b/fluentlenium-kotest-assertions/src/test/resources/logging.properties
@@ -1,0 +1,1 @@
+handlers=org.slf4j.bridge.SLF4JBridgeHandler

--- a/fluentlenium-kotest/pom.xml
+++ b/fluentlenium-kotest/pom.xml
@@ -78,6 +78,11 @@
             <version>${selenium.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jul-to-slf4j</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -122,6 +127,8 @@
 
                     <systemPropertyVariables>
                         <fluentlenium.capabilities>{"chromeOptions": {"args": ["headless","no-sandbox", "disable-gpu", "disable-dev-shm-usage"]}}</fluentlenium.capabilities>
+                        <java.util.logging.config.file>${project.basedir}/src/test/resources/logging.properties</java.util.logging.config.file>
+                        <webdriver.chrome.silentOutput>true</webdriver.chrome.silentOutput>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>

--- a/fluentlenium-kotest/src/test/resources/logging.properties
+++ b/fluentlenium-kotest/src/test/resources/logging.properties
@@ -1,0 +1,1 @@
+handlers=org.slf4j.bridge.SLF4JBridgeHandler

--- a/fluentlenium-spock/pom.xml
+++ b/fluentlenium-spock/pom.xml
@@ -84,6 +84,11 @@
             <artifactId>selenium-devtools-v95</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jul-to-slf4j</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -156,6 +161,8 @@
                     </includes>
                     <systemPropertyVariables>
                         <fluentlenium.capabilities>{"chromeOptions": {"args": ["headless","no-sandbox", "disable-gpu", "disable-dev-shm-usage"]}}</fluentlenium.capabilities>
+                        <java.util.logging.config.file>${project.basedir}/src/test/resources/logging.properties</java.util.logging.config.file>
+                        <webdriver.chrome.silentOutput>true</webdriver.chrome.silentOutput>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>

--- a/fluentlenium-spock/src/test/resources/logging.properties
+++ b/fluentlenium-spock/src/test/resources/logging.properties
@@ -1,0 +1,1 @@
+handlers=org.slf4j.bridge.SLF4JBridgeHandler

--- a/fluentlenium-spring-testng/pom.xml
+++ b/fluentlenium-spring-testng/pom.xml
@@ -82,6 +82,11 @@
             <artifactId>selenium-devtools-v95</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jul-to-slf4j</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -91,6 +96,8 @@
                 <configuration>
                     <systemPropertyVariables>
                         <fluentlenium.capabilities>{"chromeOptions": {"args": ["headless","no-sandbox", "disable-gpu", "disable-dev-shm-usage"]}}</fluentlenium.capabilities>
+                        <java.util.logging.config.file>${project.basedir}/src/test/resources/logging.properties</java.util.logging.config.file>
+                        <webdriver.chrome.silentOutput>true</webdriver.chrome.silentOutput>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>
@@ -99,6 +106,8 @@
                 <configuration>
                     <systemPropertyVariables>
                         <fluentlenium.capabilities>{"chromeOptions": {"args": ["headless","no-sandbox", "disable-gpu", "disable-dev-shm-usage"]}}</fluentlenium.capabilities>
+                        <java.util.logging.config.file>${project.basedir}/src/test/resources/logging.properties</java.util.logging.config.file>
+                        <webdriver.chrome.silentOutput>true</webdriver.chrome.silentOutput>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>

--- a/fluentlenium-spring-testng/src/test/resources/logging.properties
+++ b/fluentlenium-spring-testng/src/test/resources/logging.properties
@@ -1,0 +1,1 @@
+handlers=org.slf4j.bridge.SLF4JBridgeHandler

--- a/fluentlenium-testng/pom.xml
+++ b/fluentlenium-testng/pom.xml
@@ -74,6 +74,11 @@
             <artifactId>logback-classic</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jul-to-slf4j</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -83,6 +88,8 @@
                 <configuration>
                     <systemPropertyVariables>
                         <fluentlenium.capabilities>{"chromeOptions": {"args": ["headless","no-sandbox", "disable-gpu", "disable-dev-shm-usage"]}}</fluentlenium.capabilities>
+                        <java.util.logging.config.file>${project.basedir}/src/test/resources/logging.properties</java.util.logging.config.file>
+                        <webdriver.chrome.silentOutput>true</webdriver.chrome.silentOutput>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>

--- a/fluentlenium-testng/src/test/resources/logging.properties
+++ b/fluentlenium-testng/src/test/resources/logging.properties
@@ -1,0 +1,1 @@
+handlers=org.slf4j.bridge.SLF4JBridgeHandler

--- a/pom.xml
+++ b/pom.xml
@@ -322,6 +322,12 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>jul-to-slf4j</artifactId>
+                <version>1.7.32</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-classic</artifactId>
                 <version>1.2.7</version>


### PR DESCRIPTION
when running the Testsuite ChromeDriver Lifecycle causes lots of quite verbose log messages.

This PR does some configuration to limit the amout of ChromeDriver related logging:
* configure jul-to-slf4j Bridge to bridge Selenium Logging (uses JUL) to slf4j
* configure ChromeDriver to be less verbose (does not go via Logging)