### PR TITLE
fix URL in failing tests

### DIFF
--- a/fluentlenium-kotest-assertions/src/test/kotlin/org/fluentlenium/kotest/matchers/config/pages/FluentleniumPage.kt
+++ b/fluentlenium-kotest-assertions/src/test/kotlin/org/fluentlenium/kotest/matchers/config/pages/FluentleniumPage.kt
@@ -3,5 +3,5 @@ package org.fluentlenium.kotest.matchers.config.pages
 import org.fluentlenium.core.FluentPage
 import org.fluentlenium.core.annotation.PageUrl
 
-@PageUrl("https://fluentlenium.org")
+@PageUrl("https://fluentlenium.com/")
 class FluentleniumPage : FluentPage()

--- a/fluentlenium-kotest-assertions/src/test/kotlin/org/fluentlenium/kotest/matchers/page/PageMatchersSpec.kt
+++ b/fluentlenium-kotest-assertions/src/test/kotlin/org/fluentlenium/kotest/matchers/page/PageMatchersSpec.kt
@@ -25,7 +25,7 @@ class PageMatchersSpec : MatcherBase() {
         "haveUrl" {
             goTo(fluentleniumPage)
 
-            indexPage should haveUrl("https://fluentlenium.org/")
+            indexPage should haveUrl("https://fluentlenium.com/")
             indexPage shouldNot haveUrl("https://acme.com/")
         }
 
@@ -33,7 +33,7 @@ class PageMatchersSpec : MatcherBase() {
             goTo(fluentleniumPage)
 
             shouldAssert {
-                indexPage shouldNot haveUrl("https://fluentlenium.org/")
+                indexPage shouldNot haveUrl("https://fluentlenium.com/")
             }
 
             shouldAssert {


### PR DESCRIPTION
rename https://fluentlenium.org/ to
https://fluentlenium.com/

to fix failing tests