### PR TITLE
skip github action execution if required env vars are not present

### DIFF
--- a/.github/workflows/build-workflow.yml
+++ b/.github/workflows/build-workflow.yml
@@ -28,7 +28,7 @@ jobs:
   check-env:
     runs-on: ubuntu-latest
     outputs:
-      repo-token-available: ${{ repo-token.outputs.defined }}
+      repo-token-available: ${{ steps.repo-token.outputs.defined }}
     steps:
     - id: repo-token
       env:

--- a/.github/workflows/build-workflow.yml
+++ b/.github/workflows/build-workflow.yml
@@ -37,7 +37,7 @@ jobs:
       run: |
         mvn -B -Pjava11 clean verify jacoco:report --file pom.xml
     - name: Coveralls report
-      if: ${{ (github.repository == 'FluentLenium/FluentLenium' && github.event_name == 'push') || (github.event.pull_request.head.repo.full_name == github.repository) }}
+      if: secrets.REPO_TOKEN
       env:
         REPO_TOKEN: ${{ secrets.REPO_TOKEN }}
       run: |

--- a/.github/workflows/build-workflow.yml
+++ b/.github/workflows/build-workflow.yml
@@ -14,6 +14,17 @@ env:
   MAVEN_OPTS: "-Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
 
 jobs:
+  check-env:
+    runs-on: ubuntu-latest
+    outputs:
+      repo-token-available: ${{ steps.repo-token.outputs.defined }}
+    steps:
+      - id: repo-token
+        env:
+          REPO_TOKEN: ${{ secrets.REPO_TOKEN }}
+        if: "${{ env.REPO_TOKEN != '' }}"
+        run: echo "::set-output name=defined::true"
+
   java8-build:
     runs-on: ubuntu-latest
     steps:
@@ -24,17 +35,6 @@ jobs:
         java-version: 1.8
     - name: Java 8 - unit & integration tests
       run: mvn -B -Pjava8 clean verify --file pom.xml
-
-  check-env:
-    runs-on: ubuntu-latest
-    outputs:
-      repo-token-available: ${{ steps.repo-token.outputs.defined }}
-    steps:
-    - id: repo-token
-      env:
-        REPO_TOKEN: ${{ secrets.REPO_TOKEN }}
-      if: "${{ env.REPO_TOKEN != '' }}"
-      run: echo "::set-output name=defined::true"
 
   java11-build:
     needs: [ check-env ]

--- a/.github/workflows/build-workflow.yml
+++ b/.github/workflows/build-workflow.yml
@@ -25,7 +25,19 @@ jobs:
     - name: Java 8 - unit & integration tests
       run: mvn -B -Pjava8 clean verify --file pom.xml
 
+  check-env:
+    runs-on: ubuntu-latest
+    outputs:
+      repo-token-available: ${{ repo-token.outputs.defined }}
+    steps:
+    - id: repo-token
+      env:
+        REPO_TOKEN: ${{ secrets.REPO_TOKEN }}
+      if: "${{ env.REPO_TOKEN != '' }}"
+      run: echo "::set-output name=defined::true"
+
   java11-build:
+    needs: [ check-env ]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -37,7 +49,7 @@ jobs:
       run: |
         mvn -B -Pjava11 clean verify jacoco:report --file pom.xml
     - name: Coveralls report
-      if: secrets.REPO_TOKEN
+      if: needs.check-env.outputs.repo-token-available == 'true'
       env:
         REPO_TOKEN: ${{ secrets.REPO_TOKEN }}
       run: |

--- a/.github/workflows/e2e-workflow.yml
+++ b/.github/workflows/e2e-workflow.yml
@@ -20,14 +20,6 @@ jobs:
         if: "${{ env.URL != '' }}"
         run: echo "::set-output name=defined::true"
 
-  dump:
-    runs-on: ubuntu-latest
-    steps:
-      - name: print context
-        env:
-          GITHUB_CONTEXT: ${{ toJSON(github) }}
-        run: echo "$GITHUB_CONTEXT"
-
   edge:
     needs: [ check-env ]
     if: needs.check-env.outputs.browserStackUrl-available == 'true'

--- a/.github/workflows/e2e-workflow.yml
+++ b/.github/workflows/e2e-workflow.yml
@@ -9,6 +9,17 @@ env:
   MAVEN_OPTS: "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
 
 jobs:
+  check-env:
+    runs-on: ubuntu-latest
+    outputs:
+      browserStackUrl-available: ${{ steps.browserStackUrl.outputs.defined }}
+    steps:
+      - id: browserStackUrl
+        env:
+          URL: ${{ secrets.BROWSER_STACK_URL }}
+        if: "${{ env.URL != '' }}"
+        run: echo "::set-output name=defined::true"
+
   dump:
     runs-on: ubuntu-latest
     steps:
@@ -16,8 +27,10 @@ jobs:
         env:
           GITHUB_CONTEXT: ${{ toJSON(github) }}
         run: echo "$GITHUB_CONTEXT"
+
   edge:
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    needs: [ check-env ]
+    if: needs.check-env.outputs.browserStackUrl-available == 'true'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -31,7 +44,8 @@ jobs:
       run: mvn -B -nsu -Pexamples -pl examples/spring clean test -DbrowserName=edge -Dmobile.simulator=false -DuseHub=true -DgridUrl=${{ secrets.BROWSER_STACK_URL }}
 
   ie:
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    needs: [ check-env ]
+    if: needs.check-env.outputs.browserStackUrl-available == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -45,7 +59,8 @@ jobs:
         run: mvn -B -nsu -Pexamples -pl examples/spring clean test -DbrowserName=ie -Dmobile.simulator=false -DuseHub=true -DgridUrl=${{ secrets.BROWSER_STACK_URL }}
 
   chrome:
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    needs: [ check-env ]
+    if: needs.check-env.outputs.browserStackUrl-available == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -59,7 +74,8 @@ jobs:
         run: mvn -B -nsu -Pexamples -pl examples/spring clean test -DbrowserName=chrome -Dmobile.simulator=false -DuseHub=true -DgridUrl=${{ secrets.BROWSER_STACK_URL }}
 
   firefox:
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    needs: [ check-env ]
+    if: needs.check-env.outputs.browserStackUrl-available == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -73,7 +89,8 @@ jobs:
         run: mvn -B -nsu -Pexamples -pl examples/spring clean test -DbrowserName=firefox -Dmobile.simulator=false -DuseHub=true -DgridUrl=${{ secrets.BROWSER_STACK_URL }}
 
   safari:
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    needs: [ check-env ]
+    if: needs.check-env.outputs.browserStackUrl-available == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -87,7 +104,8 @@ jobs:
         run: mvn -B -nsu -Pexamples -pl examples/spring clean test -DbrowserName=safari -Dmobile.simulator=false -DuseHub=true -DgridUrl=${{ secrets.BROWSER_STACK_URL }}
 
   iphone:
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    needs: [ check-env ]
+    if: needs.check-env.outputs.browserStackUrl-available == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -101,7 +119,8 @@ jobs:
         run: mvn -B -nsu -Pexamples -pl examples/spring clean test -DbrowserName=iphone -Dmobile.simulator=false -DuseHub=true -DgridUrl=${{ secrets.BROWSER_STACK_URL }}
 
   android:
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    needs: [ check-env ]
+    if: needs.check-env.outputs.browserStackUrl-available == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/e2e-workflow.yml
+++ b/.github/workflows/e2e-workflow.yml
@@ -17,7 +17,7 @@ jobs:
           GITHUB_CONTEXT: ${{ toJSON(github) }}
         run: echo "$GITHUB_CONTEXT"
   edge:
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: secrets.BROWSER_STACK_URL
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -31,7 +31,7 @@ jobs:
       run: mvn -B -nsu -Pexamples -pl examples/spring clean test -DbrowserName=edge -Dmobile.simulator=false -DuseHub=true -DgridUrl=${{ secrets.BROWSER_STACK_URL }}
 
   ie:
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: secrets.BROWSER_STACK_URL
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -45,7 +45,7 @@ jobs:
         run: mvn -B -nsu -Pexamples -pl examples/spring clean test -DbrowserName=ie -Dmobile.simulator=false -DuseHub=true -DgridUrl=${{ secrets.BROWSER_STACK_URL }}
 
   chrome:
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: secrets.BROWSER_STACK_URL
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -59,7 +59,7 @@ jobs:
         run: mvn -B -nsu -Pexamples -pl examples/spring clean test -DbrowserName=chrome -Dmobile.simulator=false -DuseHub=true -DgridUrl=${{ secrets.BROWSER_STACK_URL }}
 
   firefox:
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: secrets.BROWSER_STACK_URL
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -73,7 +73,7 @@ jobs:
         run: mvn -B -nsu -Pexamples -pl examples/spring clean test -DbrowserName=firefox -Dmobile.simulator=false -DuseHub=true -DgridUrl=${{ secrets.BROWSER_STACK_URL }}
 
   safari:
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: secrets.BROWSER_STACK_URL
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -87,7 +87,7 @@ jobs:
         run: mvn -B -nsu -Pexamples -pl examples/spring clean test -DbrowserName=safari -Dmobile.simulator=false -DuseHub=true -DgridUrl=${{ secrets.BROWSER_STACK_URL }}
 
   iphone:
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: secrets.BROWSER_STACK_URL
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -101,7 +101,7 @@ jobs:
         run: mvn -B -nsu -Pexamples -pl examples/spring clean test -DbrowserName=iphone -Dmobile.simulator=false -DuseHub=true -DgridUrl=${{ secrets.BROWSER_STACK_URL }}
 
   android:
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: secrets.BROWSER_STACK_URL
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/e2e-workflow.yml
+++ b/.github/workflows/e2e-workflow.yml
@@ -17,7 +17,7 @@ jobs:
           GITHUB_CONTEXT: ${{ toJSON(github) }}
         run: echo "$GITHUB_CONTEXT"
   edge:
-    if: secrets.BROWSER_STACK_URL
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -31,7 +31,7 @@ jobs:
       run: mvn -B -nsu -Pexamples -pl examples/spring clean test -DbrowserName=edge -Dmobile.simulator=false -DuseHub=true -DgridUrl=${{ secrets.BROWSER_STACK_URL }}
 
   ie:
-    if: secrets.BROWSER_STACK_URL
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -45,7 +45,7 @@ jobs:
         run: mvn -B -nsu -Pexamples -pl examples/spring clean test -DbrowserName=ie -Dmobile.simulator=false -DuseHub=true -DgridUrl=${{ secrets.BROWSER_STACK_URL }}
 
   chrome:
-    if: secrets.BROWSER_STACK_URL
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -59,7 +59,7 @@ jobs:
         run: mvn -B -nsu -Pexamples -pl examples/spring clean test -DbrowserName=chrome -Dmobile.simulator=false -DuseHub=true -DgridUrl=${{ secrets.BROWSER_STACK_URL }}
 
   firefox:
-    if: secrets.BROWSER_STACK_URL
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -73,7 +73,7 @@ jobs:
         run: mvn -B -nsu -Pexamples -pl examples/spring clean test -DbrowserName=firefox -Dmobile.simulator=false -DuseHub=true -DgridUrl=${{ secrets.BROWSER_STACK_URL }}
 
   safari:
-    if: secrets.BROWSER_STACK_URL
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -87,7 +87,7 @@ jobs:
         run: mvn -B -nsu -Pexamples -pl examples/spring clean test -DbrowserName=safari -Dmobile.simulator=false -DuseHub=true -DgridUrl=${{ secrets.BROWSER_STACK_URL }}
 
   iphone:
-    if: secrets.BROWSER_STACK_URL
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -101,7 +101,7 @@ jobs:
         run: mvn -B -nsu -Pexamples -pl examples/spring clean test -DbrowserName=iphone -Dmobile.simulator=false -DuseHub=true -DgridUrl=${{ secrets.BROWSER_STACK_URL }}
 
   android:
-    if: secrets.BROWSER_STACK_URL
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
currently the github actions for dependabot PRs fail as some required env vars (secrets) are only available in specific contexts.
this PR adds a condition to the relevant actions to ensure they are not executed when the env vars are not available