### PR TITLE
untilAsserted should not add AssertionError multiple times

### DIFF
--- a/fluentlenium-core/src/main/java/org/fluentlenium/core/wait/FluentWait.java
+++ b/fluentlenium-core/src/main/java/org/fluentlenium/core/wait/FluentWait.java
@@ -32,6 +32,7 @@ public class FluentWait
     private boolean useDefaultException;
     private boolean messageDefined;
     private boolean defaultExceptionsRegistered;
+    private boolean ignoreAssertionErrorRegistered;
 
     /**
      * Creates a new fluent wait.
@@ -215,7 +216,10 @@ public class FluentWait
     public FluentWait untilAsserted(Runnable block) {
         updateWaitWithDefaultExceptions();
 
-        ignoreAll(Collections.singletonList(AssertionError.class));
+        if (!ignoreAssertionErrorRegistered) {
+            ignoreAll(Collections.singletonList(AssertionError.class));
+            ignoreAssertionErrorRegistered = true;
+        }
 
         wait.until(
                 (control) -> {


### PR DESCRIPTION
add guard to ensure that _untilAsserted_ adds _AssertionError_ only once to the list of ignored exceptions