### PR TITLE
simplify cache config

### DIFF
--- a/.github/workflows/build-workflow.yml
+++ b/.github/workflows/build-workflow.yml
@@ -33,12 +33,7 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 1.8
-    - name: Cache Maven packages
-      uses: actions/cache@v2
-      with:
-        path: ~/.m2
-        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-        restore-keys: ${{ runner.os }}-m2
+        cache: "maven"
     - name: Java 8 - unit & integration tests
       run: mvn -T 1C -B -Pjava8 clean verify --file pom.xml
 
@@ -51,12 +46,7 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 11
-    - name: Cache Maven packages
-      uses: actions/cache@v2
-      with:
-        path: ~/.m2
-        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-        restore-keys: ${{ runner.os }}-m2
+        cache: "maven"
     - name: Java 11 - unit & integration tests code coverage
       run: |
         mvn -T 1C -B -Pjava11 clean verify jacoco:report --file pom.xml
@@ -75,12 +65,7 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 11
-      - name: Cache Maven packages
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
+          cache: "maven"
       - name: Java 11 - unit & integration tests
         run: mvn -Dit.project.version=5.0.3-SNAPSHOT -B -Pframework-integration-tests,java11 -pl '!fluentlenium-integration-tests,!fluentlenium-kotest,!fluentlenium-kotest-assertions,!fluentlenium-cucumber,!fluentlenium-spock,!fluentlenium-coverage-report,!fluentlenium-spring-testng' clean test --file pom.xml -Dtest=*/it/* -DfailIfNoTests=false
 
@@ -92,12 +77,7 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 11
-    - name: Cache Maven packages
-      uses: actions/cache@v2
-      with:
-        path: ~/.m2
-        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-        restore-keys: ${{ runner.os }}-m2
+        cache: "maven"
     - name: Java 11 - JavaDoc
       run: mvn -B -Pjava11 javadoc:aggregate
 
@@ -109,12 +89,7 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 11
-      - name: Cache Maven packages
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
+          cache: "maven"
       - name: Install Fluentlenium
         uses: ./.github/actions/fluentlenium-maven-install
       - name: Compile gradle example
@@ -130,12 +105,7 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 11
-      - name: Cache Maven packages
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
+          cache: "maven"
       - name: Install Fluentlenium
         uses: ./.github/actions/fluentlenium-maven-install
       - name: Compile maven examples

--- a/.github/workflows/build-workflow.yml
+++ b/.github/workflows/build-workflow.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Set up JDK 1.8
       uses: actions/setup-java@v2
       with:
-        java-version: 1.8
+        java-version: 8
         distribution: 'zulu'
         cache: "maven"
     - name: Java 8 - unit & integration tests

--- a/.github/workflows/build-workflow.yml
+++ b/.github/workflows/build-workflow.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up JDK 1.8
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v2
       with:
         java-version: 1.8
         cache: "maven"
@@ -43,7 +43,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up JDK 11
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v2
       with:
         java-version: 11
         cache: "maven"
@@ -62,7 +62,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
           java-version: 11
           cache: "maven"
@@ -74,7 +74,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up JDK 11
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v2
       with:
         java-version: 11
         cache: "maven"
@@ -86,7 +86,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
           java-version: 11
           cache: "maven"
@@ -102,7 +102,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
           java-version: 11
           cache: "maven"

--- a/.github/workflows/build-workflow.yml
+++ b/.github/workflows/build-workflow.yml
@@ -33,6 +33,7 @@ jobs:
       uses: actions/setup-java@v2
       with:
         java-version: 1.8
+        distribution: 'zulu'
         cache: "maven"
     - name: Java 8 - unit & integration tests
       run: mvn -T 1C -B -Pjava8 clean verify --file pom.xml
@@ -46,6 +47,7 @@ jobs:
       uses: actions/setup-java@v2
       with:
         java-version: 11
+        distribution: 'zulu'
         cache: "maven"
     - name: Java 11 - unit & integration tests code coverage
       run: |
@@ -65,6 +67,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: 11
+          distribution: 'zulu'
           cache: "maven"
       - name: Java 11 - unit & integration tests
         run: mvn -Dit.project.version=5.0.3-SNAPSHOT -B -Pframework-integration-tests,java11 -pl '!fluentlenium-integration-tests,!fluentlenium-kotest,!fluentlenium-kotest-assertions,!fluentlenium-cucumber,!fluentlenium-spock,!fluentlenium-coverage-report,!fluentlenium-spring-testng' clean test --file pom.xml -Dtest=*/it/* -DfailIfNoTests=false
@@ -77,6 +80,7 @@ jobs:
       uses: actions/setup-java@v2
       with:
         java-version: 11
+        distribution: 'zulu'
         cache: "maven"
     - name: Java 11 - JavaDoc
       run: mvn -B -Pjava11 javadoc:aggregate
@@ -89,6 +93,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: 11
+          distribution: 'zulu'
           cache: "maven"
       - name: Install Fluentlenium
         uses: ./.github/actions/fluentlenium-maven-install
@@ -105,6 +110,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: 11
+          distribution: 'zulu'
           cache: "maven"
       - name: Install Fluentlenium
         uses: ./.github/actions/fluentlenium-maven-install


### PR DESCRIPTION
this replaces the extra action to configure caching of maven dependencies.
apparently a newer version of the setup-java action already supports that out of the box