### PR TITLE
remove duplicate programmticconfiguration instance

### DIFF
--- a/fluentlenium-core/src/main/java/org/fluentlenium/configuration/DefaultConfigurationFactory.java
+++ b/fluentlenium-core/src/main/java/org/fluentlenium/configuration/DefaultConfigurationFactory.java
@@ -35,8 +35,7 @@ public class DefaultConfigurationFactory implements ConfigurationFactory {
             }
         }
 
-        ProgrammaticConfiguration programmaticConfiguration = new ProgrammaticConfiguration();
-        Configuration configuration = new ComposedConfiguration(programmaticConfiguration, programmaticConfiguration,
+        Configuration configuration = new ComposedConfiguration(new ProgrammaticConfiguration(),
                 new PropertiesBackendConfiguration(new SystemPropertiesBackend()),
                 new PropertiesBackendConfiguration(new EnvironmentVariablesBackend()),
                 new AnnotationConfiguration(containerClass),


### PR DESCRIPTION
minor fix
ProgrammaticConfiguration is apparently passed in twice to ComposedConfiguration.

I assume this is by accident and not necessary -> removing the 2nd one