### PR TITLE
allow loose json capabilites string parsing

### DIFF
--- a/fluentlenium-core/pom.xml
+++ b/fluentlenium-core/pom.xml
@@ -96,6 +96,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.jodd</groupId>
+            <artifactId>jodd-json</artifactId>
+            <version>6.0.3</version>
+        </dependency>
+
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/fluentlenium-core/src/main/java/org/fluentlenium/configuration/AnnotationConfiguration.java
+++ b/fluentlenium-core/src/main/java/org/fluentlenium/configuration/AnnotationConfiguration.java
@@ -1,10 +1,10 @@
 package org.fluentlenium.configuration;
 
+import jodd.json.JsonException;
+import jodd.json.JsonParser;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.openqa.selenium.Capabilities;
-import org.openqa.selenium.json.Json;
-import org.openqa.selenium.json.JsonException;
 import org.openqa.selenium.remote.DesiredCapabilities;
 
 import java.io.IOException;
@@ -28,7 +28,7 @@ public class AnnotationConfiguration extends BaseConfiguration implements Config
 
     private final Map<String, String> customProperties = new HashMap<>();
 
-    private final Json jsonConverter = new Json();
+    private final JsonParser jsonConverter = new JsonParser().looseMode(true);
 
     /**
      * Creates a new annotation based configuration.
@@ -101,7 +101,7 @@ public class AnnotationConfiguration extends BaseConfiguration implements Config
 
     private Capabilities convertJsonPropertyToCapabilities(String property) {
         try {
-            return jsonConverter.toType(property, DesiredCapabilities.class);
+            return jsonConverter.parse(property, DesiredCapabilities.class);
         } catch (JsonException e) {
             throw new ConfigurationException("Can't convert JSON Capabilities to Object.", e);
         }

--- a/fluentlenium-core/src/main/java/org/fluentlenium/configuration/FluentConfiguration.java
+++ b/fluentlenium-core/src/main/java/org/fluentlenium/configuration/FluentConfiguration.java
@@ -1,10 +1,6 @@
 package org.fluentlenium.configuration;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Inherited;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+import java.lang.annotation.*;
 
 /**
  * Configure a FluentLenium test class with this annotation.
@@ -82,6 +78,13 @@ public @interface FluentConfiguration {
      * @see ConfigurationProperties#getCapabilities()
      */
     String capabilities() default "";
+
+    /**
+     * enable lenient json parser for capabilities
+     *
+     * @return true or false
+     */
+    boolean enableLooseCapabilitesJson() default true;
 
     /**
      * <i>driverLifecycle</i> property.

--- a/fluentlenium-core/src/test/java/org/fluentlenium/configuration/AnnotationConfigurationTest.java
+++ b/fluentlenium-core/src/test/java/org/fluentlenium/configuration/AnnotationConfigurationTest.java
@@ -1,13 +1,14 @@
 package org.fluentlenium.configuration;
 
 import org.assertj.core.api.Assertions;
+import org.fluentlenium.configuration.PropertiesBackendConfigurationTest.DummyConfigurationDefaults;
+import org.fluentlenium.configuration.PropertiesBackendConfigurationTest.DummyConfigurationFactory;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.openqa.selenium.remote.DesiredCapabilities;
 
-import org.fluentlenium.configuration.PropertiesBackendConfigurationTest.DummyConfigurationDefaults;
-import org.fluentlenium.configuration.PropertiesBackendConfigurationTest.DummyConfigurationFactory;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 /**
  * Unit test for {@link AnnotationConfiguration}.
@@ -55,6 +56,11 @@ public class AnnotationConfigurationTest {
 
     @FluentConfiguration
     public static class DefaultClass {
+    }
+
+    @FluentConfiguration(capabilities = "{javascriptEnabled: true}")
+    public static class LooseJson {
+
     }
 
     @BeforeClass
@@ -280,5 +286,11 @@ public class AnnotationConfigurationTest {
         Assertions.assertThat(defaultConfiguration.getCustomProperty("key")).isNull();
 
         Assertions.assertThat(configuration.getCustomProperty("key")).isEqualTo("value");
+    }
+
+    @Test
+    public void looseJson() {
+        AnnotationConfiguration looseJson = new AnnotationConfiguration(LooseJson.class);
+        assertThat(looseJson.getCapabilities().getCapability("javascriptEnabled")).isEqualTo(true);
     }
 }


### PR DESCRIPTION
I found it useful to have a more loose json capabilities parser. It allows to write a capabilites string like this (quotes can be omitted and thus dont need to be escaped)

`@FluentConfiguration(capabilities = "{javascriptEnabled: true}")`

@filipcynarski @slawekradzyminski 
what do you think of this?