### PR TITLE
make fluentlenium-kotest work with datadriven tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -201,3 +201,5 @@ settings.xml
 Gemfile.lock
 
 examples/spring/gridurl.txt
+
+.sdkmanrc

--- a/fluentlenium-kotest/pom.xml
+++ b/fluentlenium-kotest/pom.xml
@@ -55,6 +55,12 @@
             <artifactId>kotest-runner-junit5-jvm</artifactId>
             <version>${kotest.version}</version>
         </dependency>
+        <dependency>
+            <groupId>io.kotest</groupId>
+            <artifactId>kotest-framework-datatest-jvm</artifactId>
+            <version>${kotest.version}</version>
+            <scope>test</scope>
+        </dependency>
 
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>

--- a/fluentlenium-kotest/src/test/kotlin/org/fluentlenium/adapter/kotest/behaviorspec/DataDrivenSpec.kt
+++ b/fluentlenium-kotest/src/test/kotlin/org/fluentlenium/adapter/kotest/behaviorspec/DataDrivenSpec.kt
@@ -1,0 +1,23 @@
+package org.fluentlenium.adapter.kotest.behaviorspec
+
+import io.kotest.datatest.withData
+import org.fluentlenium.adapter.kotest.FluentBehaviorSpec
+import org.fluentlenium.adapter.kotest.TestConstants
+
+class DataDrivenSpec : FluentBehaviorSpec({
+    given("given") {
+        `when`("when") {
+            withData(listOf("A", "B")) {
+                goTo(TestConstants.DEFAULT_URL)
+            }
+        }
+
+        withData(listOf("C")) {
+            goTo(TestConstants.DEFAULT_URL)
+        }
+    }
+
+    withData(listOf("D")) {
+        goTo(TestConstants.DEFAULT_URL)
+    }
+})

--- a/fluentlenium-kotest/src/test/kotlin/org/fluentlenium/adapter/kotest/describespec/DataDrivenSpec.kt
+++ b/fluentlenium-kotest/src/test/kotlin/org/fluentlenium/adapter/kotest/describespec/DataDrivenSpec.kt
@@ -1,0 +1,11 @@
+package org.fluentlenium.adapter.kotest.describespec
+
+import io.kotest.datatest.withData
+import org.fluentlenium.adapter.kotest.FluentDescribeSpec
+import org.fluentlenium.adapter.kotest.TestConstants
+
+class DataDrivenSpec : FluentDescribeSpec({
+    withData(listOf("A", "B")) {
+        goTo(TestConstants.DEFAULT_URL)
+    }
+})

--- a/fluentlenium-kotest/src/test/kotlin/org/fluentlenium/adapter/kotest/describespec/FluentleniumKotestLifecycleSpec.kt
+++ b/fluentlenium-kotest/src/test/kotlin/org/fluentlenium/adapter/kotest/describespec/FluentleniumKotestLifecycleSpec.kt
@@ -4,8 +4,12 @@ import io.kotest.matchers.string.shouldContain
 import org.fluentlenium.adapter.kotest.FluentDescribeSpec
 import org.fluentlenium.adapter.kotest.TestConstants.DEFAULT_URL
 
-class CanAccessDriverInAfterTestSpec : FluentDescribeSpec() {
+class FluentleniumKotestLifecycleSpec : FluentDescribeSpec() {
     init {
+        beforeTest {
+            goTo(DEFAULT_URL)
+        }
+
         it("can user browser in afterTest") {
             goTo(DEFAULT_URL)
             window().title() shouldContain "Fluent"

--- a/fluentlenium-kotest/src/test/kotlin/org/fluentlenium/adapter/kotest/expectspec/DataDrivenSpec.kt
+++ b/fluentlenium-kotest/src/test/kotlin/org/fluentlenium/adapter/kotest/expectspec/DataDrivenSpec.kt
@@ -1,0 +1,17 @@
+package org.fluentlenium.adapter.kotest.expectspec
+
+import io.kotest.datatest.withData
+import org.fluentlenium.adapter.kotest.FluentExpectSpec
+import org.fluentlenium.adapter.kotest.TestConstants
+
+class DataDrivenSpec : FluentExpectSpec({
+    context("context") {
+        withData(listOf("A", "B")) {
+            goTo(TestConstants.DEFAULT_URL)
+        }
+    }
+
+    withData(listOf("C")) {
+        goTo(TestConstants.DEFAULT_URL)
+    }
+})

--- a/fluentlenium-kotest/src/test/kotlin/org/fluentlenium/adapter/kotest/featurespec/DataDrivenSpec.kt
+++ b/fluentlenium-kotest/src/test/kotlin/org/fluentlenium/adapter/kotest/featurespec/DataDrivenSpec.kt
@@ -1,0 +1,17 @@
+package org.fluentlenium.adapter.kotest.featurespec
+
+import io.kotest.datatest.withData
+import org.fluentlenium.adapter.kotest.FluentFeatureSpec
+import org.fluentlenium.adapter.kotest.TestConstants
+
+class DataDrivenSpec : FluentFeatureSpec({
+    feature("feature") {
+        withData(listOf("A", "B")) {
+            goTo(TestConstants.DEFAULT_URL)
+        }
+    }
+
+    withData(listOf("C")) {
+        goTo(TestConstants.DEFAULT_URL)
+    }
+})

--- a/fluentlenium-kotest/src/test/kotlin/org/fluentlenium/adapter/kotest/freespec/DataDrivenSpec.kt
+++ b/fluentlenium-kotest/src/test/kotlin/org/fluentlenium/adapter/kotest/freespec/DataDrivenSpec.kt
@@ -1,0 +1,25 @@
+package org.fluentlenium.adapter.kotest.freespec
+
+import io.kotest.datatest.withData
+import org.fluentlenium.adapter.kotest.FluentFreeSpec
+import org.fluentlenium.adapter.kotest.TestConstants
+
+class DataDrivenSpec : FluentFreeSpec({
+    "free" - {
+        withData(listOf("A", "B")) {
+            goTo(TestConstants.DEFAULT_URL)
+        }
+    }
+
+    "nested" - {
+        "inner" - {
+            withData(listOf("C", "D")) {
+                goTo(TestConstants.DEFAULT_URL)
+            }
+        }
+    }
+
+    withData(listOf("E")) {
+        goTo(TestConstants.DEFAULT_URL)
+    }
+})

--- a/fluentlenium-kotest/src/test/kotlin/org/fluentlenium/adapter/kotest/funspec/DataDrivenSpec.kt
+++ b/fluentlenium-kotest/src/test/kotlin/org/fluentlenium/adapter/kotest/funspec/DataDrivenSpec.kt
@@ -1,0 +1,11 @@
+package org.fluentlenium.adapter.kotest.funspec
+
+import io.kotest.datatest.withData
+import org.fluentlenium.adapter.kotest.FluentFunSpec
+import org.fluentlenium.adapter.kotest.TestConstants
+
+class DataDrivenSpec : FluentFunSpec({
+    withData(listOf("A")) {
+        goTo(TestConstants.DEFAULT_URL)
+    }
+})

--- a/fluentlenium-kotest/src/test/kotlin/org/fluentlenium/adapter/kotest/shouldspec/DataDrivenSpec.kt
+++ b/fluentlenium-kotest/src/test/kotlin/org/fluentlenium/adapter/kotest/shouldspec/DataDrivenSpec.kt
@@ -1,0 +1,17 @@
+package org.fluentlenium.adapter.kotest.shouldspec
+
+import io.kotest.datatest.withData
+import org.fluentlenium.adapter.kotest.FluentShouldSpec
+import org.fluentlenium.adapter.kotest.TestConstants
+
+class DataDrivenSpec : FluentShouldSpec({
+    context("context") {
+        withData(listOf("A")) {
+            goTo(TestConstants.DEFAULT_URL)
+        }
+    }
+
+    withData(listOf("B")) {
+        goTo(TestConstants.DEFAULT_URL)
+    }
+})

--- a/fluentlenium-kotest/src/test/kotlin/org/fluentlenium/adapter/kotest/stringspec/DataDrivenSpec.kt
+++ b/fluentlenium-kotest/src/test/kotlin/org/fluentlenium/adapter/kotest/stringspec/DataDrivenSpec.kt
@@ -1,0 +1,11 @@
+package org.fluentlenium.adapter.kotest.stringspec
+
+import io.kotest.datatest.withData
+import org.fluentlenium.adapter.kotest.FluentStringSpec
+import org.fluentlenium.adapter.kotest.TestConstants
+
+class DataDrivenSpec : FluentStringSpec({
+    withData(listOf("A", "B")) {
+        goTo(TestConstants.DEFAULT_URL)
+    }
+})

--- a/fluentlenium-kotest/src/test/kotlin/org/fluentlenium/adapter/kotest/wordspec/DataDrivenSpec.kt
+++ b/fluentlenium-kotest/src/test/kotlin/org/fluentlenium/adapter/kotest/wordspec/DataDrivenSpec.kt
@@ -1,0 +1,17 @@
+package org.fluentlenium.adapter.kotest.wordspec
+
+import io.kotest.datatest.withData
+import org.fluentlenium.adapter.kotest.FluentWordSpec
+import org.fluentlenium.adapter.kotest.TestConstants
+
+class DataDrivenSpec : FluentWordSpec({
+    "word spec" should {
+        withData(listOf("A")) {
+            goTo(TestConstants.DEFAULT_URL)
+        }
+    }
+
+    withData(listOf("B")) {
+        goTo(TestConstants.DEFAULT_URL)
+    }
+})


### PR DESCRIPTION
Kotest is not invoking _afterEach_ for dynamic tests. In consequence the browser was not properly stopped between tests. Using _afterAny_ now