### PR TITLE
configure java 11 as compiler default

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -361,6 +361,10 @@
                 <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.10.1</version>
+
+                    <configuration>
+                        <release>11</release>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <artifactId>maven-deploy-plugin</artifactId>


### PR DESCRIPTION
configure java 11 as default for the maven-compiler-plugin