### PR TITLE
try to fix NPE that happens during build in kotlin plugin

### DIFF
--- a/.github/workflows/build-workflow.yml
+++ b/.github/workflows/build-workflow.yml
@@ -11,7 +11,7 @@ on:
     branches: [ develop ]
 
 env:
-  MAVEN_OPTS: "-Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
+  MAVEN_OPTS: "-Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -Didea.ignore.disabled.plugins=true"
 
 jobs:
   check-env:


### PR DESCRIPTION
some CI builds fail with the exception described here: https://youtrack.jetbrains.com/issue/KT-44931

example: https://github.com/FluentLenium/FluentLenium/actions/runs/3797757032/jobs/6458963058

trying to apply the workaround that is described in the youtrack ticket