### PR TITLE
switch to wagon maven resolver

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,4 +1,13 @@
 --add-opens java.base/java.lang=ALL-UNNAMED
--Dmaven.resolver.transport=native
+-Dmaven.resolver.transport=wagon
 -Daether.connector.requestTimeout=720000
 -Daether.connector.http.retryHandler.count=5
+-Xss1500k
+-Xmx1024m
+-Dhttp.keepAlive=false
+-Dmaven.wagon.http.pool=false
+-Dmaven.wagon.http.retryHandler.class=standard
+-Dmaven.wagon.http.retryHandler.count=3
+-Dmaven.wagon.http.retryHandler.requestSentEnabled=true
+-Dmaven.wagon.http.serviceUnavailableRetryStrategy.class=standard
+-Dmaven.wagon.rto=60000


### PR DESCRIPTION
the MR https://github.com/FluentLenium/FluentLenium/pull/1855 changed the maven resolver to the new native implementation.

After experiencing some hanging maven builds i suspected the mentioned MR to be the cause (example https://github.com/FluentLenium/FluentLenium/actions/runs/4769384434/jobs/8479694627). hanging builds will be terminated after a specified timeout (e.g. https://github.com/FluentLenium/FluentLenium/blob/develop/.github/workflows/build-workflow.yml#L61)

this MR changes back to the old maven wagon resolver. will re-run the github build a couple of times to check for any hanging builds 