### PR TITLE
Fix removal of AbstractEventListener + EventFiringWebDriver + WebDriverEventListener

### DIFF
--- a/fluentlenium-core/src/main/java/io/fluentlenium/adapter/sharedwebdriver/SharedWebdriverSingletonImpl.java
+++ b/fluentlenium-core/src/main/java/io/fluentlenium/adapter/sharedwebdriver/SharedWebdriverSingletonImpl.java
@@ -7,7 +7,7 @@ import io.fluentlenium.configuration.ConfigurationProperties.DriverLifecycle;
 import io.fluentlenium.configuration.WebDrivers;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.support.events.EventFiringWebDriver;
+import org.openqa.selenium.support.events.EventFiringWebDriver; // TODO
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -227,7 +227,7 @@ class SharedWebdriverSingletonImpl {
     public WebDriver newWebDriver(String name, Capabilities capabilities, Configuration configuration) {
         WebDriver webDriver = WebDrivers.INSTANCE.newWebDriver(name, capabilities, configuration);
         if (Boolean.TRUE.equals(configuration.getEventsEnabled())) {
-            webDriver = new EventFiringWebDriver(webDriver);
+            webDriver = new EventFiringWebDriver(webDriver); // TODO new EventFiringDecorator().decorate(webDriver)
         }
         return webDriver;
     }

--- a/fluentlenium-core/src/main/java/io/fluentlenium/core/FluentDriver.java
+++ b/fluentlenium-core/src/main/java/io/fluentlenium/core/FluentDriver.java
@@ -38,7 +38,7 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.WrapsElement;
-import org.openqa.selenium.support.events.EventFiringWebDriver;
+import org.openqa.selenium.support.events.EventFiringWebDriver; // TODO
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -91,7 +91,7 @@ public class FluentDriver extends AbstractFluentDriverSearchControl { // NOPMD G
         driverWait = new FluentDriverWait(configuration);
         this.driver = driver;
         search = new Search(driver, this, componentsManager, adapter);
-        if (driver instanceof EventFiringWebDriver) {
+        if (driver instanceof EventFiringWebDriver) { // TODO
             events = new EventsRegistry(this);
             componentsEventsRegistry = new ComponentsEventsRegistry(events, componentsManager);
         } else {

--- a/fluentlenium-core/src/main/java/io/fluentlenium/utils/chromium/ChromiumControlImpl.java
+++ b/fluentlenium-core/src/main/java/io/fluentlenium/utils/chromium/ChromiumControlImpl.java
@@ -13,8 +13,8 @@ public class ChromiumControlImpl implements ChromiumControl {
     }
 
     public final ChromiumApi getChromiumApi() {
-        if (driver instanceof EventFiringWebDriver) {
-            driver = ((EventFiringWebDriver) driver).getWrappedDriver();
+        if (driver instanceof EventFiringWebDriver) { // TODO
+            driver = ((EventFiringWebDriver) driver).getWrappedDriver(); // TODO
         }
 
         RemoteWebDriver remoteWebDriver;

--- a/fluentlenium-core/src/test/java/io/fluentlenium/adapter/FluentAdapterTest.java
+++ b/fluentlenium-core/src/test/java/io/fluentlenium/adapter/FluentAdapterTest.java
@@ -15,7 +15,7 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WrapsDriver;
 import org.openqa.selenium.htmlunit.HtmlUnitDriver;
 import org.openqa.selenium.remote.DesiredCapabilities;
-import org.openqa.selenium.support.events.EventFiringWebDriver;
+import org.openqa.selenium.support.events.EventFiringWebDriver; // TODO
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
@@ -114,8 +114,8 @@ public class FluentAdapterTest {
             newWebDriver = adapter.newWebDriver();
             newWebDriver2 = adapter.newWebDriver();
 
-            assertThat(newWebDriver).isNotSameAs(newWebDriver2).isInstanceOf(EventFiringWebDriver.class);
-            assertThat(newWebDriver2).isInstanceOf(EventFiringWebDriver.class);
+            assertThat(newWebDriver).isNotSameAs(newWebDriver2).isInstanceOf(EventFiringWebDriver.class); // TODO
+            assertThat(newWebDriver2).isInstanceOf(EventFiringWebDriver.class); // TODO
 
             assertThat(((WrapsDriver) newWebDriver).getWrappedDriver()).isInstanceOf(HtmlUnitDriver.class);
             assertThat(((WrapsDriver) newWebDriver).getWrappedDriver()).isInstanceOf(HtmlUnitDriver.class);

--- a/fluentlenium-junit-jupiter/src/it/junit-jupiter/pom.xml
+++ b/fluentlenium-junit-jupiter/src/it/junit-jupiter/pom.xml
@@ -18,7 +18,7 @@
 
     <properties>
         <it.project.version>6.0.0-SNAPSHOT</it.project.version>
-        <selenium.version>4.16.1</selenium.version>
+        <selenium.version>4.28.1</selenium.version>
         <fluentlenium.capabilities.default>{"goog:chromeOptions": {"args": ["headless=new","no-sandbox", "disable-gpu",
             "disable-dev-shm-usage"]}}
         </fluentlenium.capabilities.default>
@@ -50,7 +50,7 @@
             <dependency>
                 <groupId>org.seleniumhq.selenium</groupId>
                 <artifactId>selenium-chrome-driver</artifactId>
-                <version>4.16.1</version>
+                <version>4.28.1</version>
             </dependency>
             <dependency>
                 <groupId>io.github.bonigarcia</groupId>

--- a/fluentlenium-junit/src/it/junit/pom.xml
+++ b/fluentlenium-junit/src/it/junit/pom.xml
@@ -49,7 +49,7 @@
             <dependency>
                 <groupId>org.seleniumhq.selenium</groupId>
                 <artifactId>selenium-chrome-driver</artifactId>
-                <version>4.16.1</version>
+                <version>4.28.1</version>
             </dependency>
             <dependency>
                 <groupId>io.github.bonigarcia</groupId>

--- a/fluentlenium-testng/src/it/testng/pom.xml
+++ b/fluentlenium-testng/src/it/testng/pom.xml
@@ -50,7 +50,7 @@
             <dependency>
                 <groupId>org.seleniumhq.selenium</groupId>
                 <artifactId>selenium-chrome-driver</artifactId>
-                <version>4.16.1</version>
+                <version>4.28.1</version>
             </dependency>
             <dependency>
                 <groupId>io.github.bonigarcia</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>${project.build.sourceEncoding}</project.reporting.outputEncoding>
-        <selenium.version>4.16.1</selenium.version>
+        <selenium.version>4.28.1</selenium.version>
         <testng.version>7.9.0</testng.version>
         <junit5.version>5.10.2</junit5.version>
         <spring.version>6.2.2</spring.version>

--- a/pom.xml
+++ b/pom.xml
@@ -236,7 +236,7 @@
             <dependency>
                 <groupId>org.htmlunit</groupId>
                 <artifactId>htmlunit</artifactId>
-                <version>4.1.0</version>
+                <version>4.9.0</version>
             </dependency>
             <dependency>
                 <groupId>org.jetbrains</groupId>


### PR DESCRIPTION
- Working towards fixing #1399
- The `EventFiringWebDriver` api docs are gone, but we are lucky here: https://web.archive.org/web/20240105095730/https://www.selenium.dev/selenium/docs/api/java/org/openqa/selenium/support/events/EventFiringWebDriver.html

Useful:
- https://www.selenium.dev/blog/2023/java-removal-of-deprecated-events-classes/
- https://github.com/SeleniumHQ/selenium/blob/trunk/java/CHANGELOG
- https://github.com/SeleniumHQ/htmlunit-driver/releases
- https://www.selenium.dev/selenium/docs/api/java/org/openqa/selenium/support/events/EventFiringDecorator.html
- https://www.selenium.dev/selenium/docs/api/java/org/openqa/selenium/support/events/WebDriverListener.html